### PR TITLE
Use appender for Arrow IPC Buffer, unify pushdown logic between file and buffer, and separate factories for file and buffer

### DIFF
--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install required node packages
         run: |
-          sudo npm i duckdb@1.1.4-dev13.0
+          sudo npm i duckdb@1.2.0
           sudo npm install -g  apache-arrow mocha
           sudo npm install  apache-arrow mocha
           npm -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ set(EXTENSION_SOURCES
     src/scanner/read_arrow.cpp
     src/scanner/scan_arrow_ipc.cpp
     src/nanoarrow_extension.cpp
+    src/writer/arrow_stream_writer.cpp
+    src/writer/column_data_collection_serializer.cpp
     src/writer/write_arrow_stream.cpp
     src/writer/to_arrow_ipc.cpp)
 

--- a/src/include/ipc/stream_reader/base_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/base_stream_reader.hpp
@@ -22,7 +22,7 @@
 namespace duckdb {
 namespace ext_nanoarrow {
 
-// Missing in nanoarrow_ipc.hpp
+//! Missing in nanoarrow_ipc.hpp
 struct UniqueSharedBuffer {
   struct ArrowIpcSharedBuffer data{};
 
@@ -63,8 +63,8 @@ class IPCStreamReader {
 
  protected:
   virtual void EnsureInputStreamAligned() {
-    // nop by default. This method is called in the DecodeMessage() and necessary only for
-    // the file reader, for the buffer reader it does nothing.
+    //! nop by default. This method is called in the DecodeMessage() and necessary only
+    //! for the file reader, for the buffer reader it does nothing.
   }
   virtual void ReadData(data_ptr_t ptr, idx_t size) {
     throw InternalException("IPCStreamReader::ReadData not implemented");

--- a/src/include/writer/arrow_stream_writer.hpp
+++ b/src/include/writer/arrow_stream_writer.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 #include "writer/column_data_collection_serializer.hpp"
+#include "duckdb/main/client_context.hpp"
+
 namespace duckdb {
 namespace ext_nanoarrow {
 
@@ -15,83 +17,27 @@ struct ArrowStreamWriter {
   ArrowStreamWriter(ClientContext& context, FileSystem& fs, const string& file_path,
                     const vector<LogicalType>& logical_types,
                     const vector<string>& column_names,
-                    const vector<pair<string, string>>& metadata)
-      : options(context.GetClientProperties()),
-        allocator(BufferAllocator::Get(context)),
-        serializer(options, allocator),
-        file_name(file_path),
-        logical_types(logical_types) {
-    InitSchema(logical_types, column_names, metadata);
-    InitOutputFile(fs, file_path);
-  }
+                    const vector<pair<string, string>>& metadata);
 
   void InitSchema(const vector<LogicalType>& logical_types,
                   const vector<string>& column_names,
-                  const vector<pair<string, string>>& metadata) {
-    nanoarrow::UniqueSchema tmp_schema;
-    ArrowConverter::ToArrowSchema(tmp_schema.get(), logical_types, column_names, options);
+                  const vector<pair<string, string>>& metadata);
 
-    if (metadata.empty()) {
-      ArrowSchemaMove(tmp_schema.get(), schema.get());
-    } else {
-      nanoarrow::UniqueBuffer metadata_packed;
-      NANOARROW_THROW_NOT_OK(
-          ArrowMetadataBuilderInit(metadata_packed.get(), tmp_schema->metadata));
-      ArrowStringView key;
-      ArrowStringView value;
-      for (const auto& item : metadata) {
-        key = {item.first.data(), static_cast<int64_t>(item.first.size())};
-        value = {item.second.data(), static_cast<int64_t>(item.second.size())};
-        NANOARROW_THROW_NOT_OK(
-            ArrowMetadataBuilderAppend(metadata_packed.get(), key, value));
-      }
+  void InitOutputFile(FileSystem& fs, const string& file_path);
 
-      NANOARROW_THROW_NOT_OK(ArrowSchemaDeepCopy(tmp_schema.get(), schema.get()));
-      NANOARROW_THROW_NOT_OK(ArrowSchemaSetMetadata(
-          schema.get(), reinterpret_cast<char*>(metadata_packed->data)));
-    }
+  void WriteSchema();
 
-    serializer.Init(schema.get(), logical_types);
-  }
+  unique_ptr<ColumnDataCollectionSerializer> NewSerializer();
 
-  void InitOutputFile(FileSystem& fs, const string& file_path) {
-    writer = make_uniq<BufferedFileWriter>(
-        fs, file_path.c_str(),
-        FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  }
+  void Flush(ColumnDataCollection& buffer);
 
-  void WriteSchema() {
-    serializer.SerializeSchema();
-    serializer.Flush(*writer);
-  }
+  void Flush(ColumnDataCollectionSerializer& serializer);
 
-  unique_ptr<ColumnDataCollectionSerializer> NewSerializer() {
-    auto serializer = make_uniq<ColumnDataCollectionSerializer>(options, allocator);
-    serializer->Init(schema.get(), logical_types);
-    return serializer;
-  }
+  void Finalize() const;
 
-  void Flush(ColumnDataCollection& buffer) {
-    serializer.Serialize(buffer);
-    buffer.Reset();
-    serializer.Flush(*writer);
-    ++row_group_count;
-  }
+  idx_t NumberOfRowGroups() const;
 
-  void Flush(ColumnDataCollectionSerializer& serializer) {
-    serializer.Flush(*writer);
-    ++row_group_count;
-  }
-
-  void Finalize() {
-    uint8_t end_of_stream[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00};
-    writer->WriteData(end_of_stream, sizeof(end_of_stream));
-    writer->Close();
-  }
-
-  idx_t NumberOfRowGroups() { return row_group_count; }
-
-  idx_t FileSize() { return writer->GetTotalWritten(); }
+  idx_t FileSize() const;
 
  private:
   ClientProperties options;

--- a/src/include/writer/arrow_stream_writer.hpp
+++ b/src/include/writer/arrow_stream_writer.hpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include "writer/column_data_collection_serializer.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "writer/column_data_collection_serializer.hpp"
 
 namespace duckdb {
 namespace ext_nanoarrow {

--- a/src/include/writer/column_data_collection_serializer.hpp
+++ b/src/include/writer/column_data_collection_serializer.hpp
@@ -21,12 +21,13 @@ namespace ext_nanoarrow {
 
 class ColumnDataCollectionSerializer {
  public:
-  ColumnDataCollectionSerializer(ClientProperties  options, Allocator& allocator);
+  ColumnDataCollectionSerializer(ClientProperties options, Allocator& allocator);
 
   void Init(const ArrowSchema* schema_p, const vector<LogicalType>& logical_types);
 
   void SerializeSchema();
 
+  idx_t Serialize(ArrowArray& array);
   idx_t Serialize(DataChunk& chunk);
 
   idx_t Serialize(const ColumnDataCollection& buffer);

--- a/src/include/writer/column_data_collection_serializer.hpp
+++ b/src/include/writer/column_data_collection_serializer.hpp
@@ -19,120 +19,28 @@
 namespace duckdb {
 namespace ext_nanoarrow {
 
-// Initialize buffer whose realloc operations go through DuckDB's memory
-// accounting. Note that the Allocator must outlive the buffer (true for
-// the case of this writer, but maybe not true for generic production of
-// ArrowArrays whose lifetime might outlive the connection/database).
-inline void InitArrowDuckBuffer(ArrowBuffer* buffer, Allocator& duck_allocator) {
-  ArrowBufferInit(buffer);
-
-  buffer->allocator.reallocate = [](ArrowBufferAllocator* allocator, uint8_t* ptr,
-                                    int64_t old_size, int64_t new_size) -> uint8_t* {
-    NANOARROW_DCHECK(allocator->private_data != nullptr);
-    auto duck_allocator = reinterpret_cast<Allocator*>(allocator->private_data);
-    if (ptr == nullptr && new_size > 0) {
-      return duck_allocator->AllocateData(new_size);
-    } else if (new_size == 0) {
-      duck_allocator->FreeData(ptr, old_size);
-      return nullptr;
-    } else {
-      return duck_allocator->ReallocateData(ptr, old_size, new_size);
-    }
-  };
-
-  buffer->allocator.free = [](ArrowBufferAllocator* allocator, uint8_t* ptr,
-                              int64_t old_size) {
-    NANOARROW_DCHECK(allocator->private_data != nullptr);
-    auto duck_allocator = reinterpret_cast<Allocator*>(allocator->private_data);
-    duck_allocator->FreeData(ptr, old_size);
-  };
-
-  buffer->allocator.private_data = &duck_allocator;
-}
-
 class ColumnDataCollectionSerializer {
  public:
-  ColumnDataCollectionSerializer(ClientProperties& options, Allocator& allocator)
-      : options(options), allocator(allocator) {}
+  ColumnDataCollectionSerializer(ClientProperties  options, Allocator& allocator);
 
-  void Init(ArrowSchema* schema_p, const vector<LogicalType>& logical_types) {
-    InitArrowDuckBuffer(header.get(), allocator);
-    InitArrowDuckBuffer(body.get(), allocator);
-    NANOARROW_THROW_NOT_OK(ArrowIpcEncoderInit(encoder.get()));
-    THROW_NOT_OK(InternalException, &error,
-                 ArrowArrayViewInitFromSchema(chunk_view.get(), schema_p, &error));
+  void Init(const ArrowSchema* schema_p, const vector<LogicalType>& logical_types);
 
-    schema = schema_p;
+  void SerializeSchema();
 
-    extension_types =
-        ArrowTypeExtensionData::GetExtensionTypes(*options.client_context, logical_types);
-  }
+  idx_t Serialize(DataChunk& chunk);
 
-  void SerializeSchema() {
-    header->size_bytes = 0;
-    body->size_bytes = 0;
-    THROW_NOT_OK(InternalException, &error,
-                 ArrowIpcEncoderEncodeSchema(encoder.get(), schema, &error));
-    NANOARROW_THROW_NOT_OK(
-        ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
-  }
+  idx_t Serialize(const ColumnDataCollection& buffer);
 
-  idx_t Serialize(DataChunk& chunk) {
-    header->size_bytes = 0;
-    body->size_bytes = 0;
-    chunk_arrow.reset();
+  void Flush(BufferedFileWriter& writer);
 
-    ArrowConverter::ToArrowArray(chunk, chunk_arrow.get(), options, extension_types);
-    THROW_NOT_OK(duckdb::InternalException, &error,
-                 ArrowArrayViewSetArray(chunk_view.get(), chunk_arrow.get(), &error));
-    THROW_NOT_OK(InternalException, &error,
-                 ArrowIpcEncoderEncodeSimpleRecordBatch(encoder.get(), chunk_view.get(),
-                                                        body.get(), &error));
-    NANOARROW_THROW_NOT_OK(
-        ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+  nanoarrow::UniqueBuffer GetHeader();
 
-    return 1;
-  }
-
-  idx_t Serialize(const ColumnDataCollection& buffer) {
-    header->size_bytes = 0;
-    body->size_bytes = 0;
-    if (buffer.Count() == 0) {
-      return 0;
-    }
-    // The ArrowConverter requires all of this to be in one big DataChunk.
-    // It would be better to append these one at a time using other DuckDB
-    // internals like the ArrowAppender. (Possibly better would be to skip the
-    // owning ArrowArray entirely and just expose an ArrowArrayView of the
-    // chunk. keeping track of any owning elements that had to be allocated,
-    // since that's all that is strictly required to write).
-    DataChunk chunk;
-    chunk.Initialize(allocator, buffer.Types(), buffer.Count());
-    for (const auto& item : buffer.Chunks()) {
-      chunk.Append(item, true);
-    }
-    return Serialize(chunk);
-  }
-
-  void Flush(BufferedFileWriter& writer) {
-    writer.WriteData(header->data, header->size_bytes);
-    writer.WriteData(body->data, body->size_bytes);
-  }
-  nanoarrow::UniqueBuffer GetHeader() {
-    auto result_header = std::move(header);
-    InitArrowDuckBuffer(header.get(), allocator);
-    return result_header;
-  }
-  nanoarrow::UniqueBuffer GetBody() {
-    auto result_body = std::move(body);
-    InitArrowDuckBuffer(body.get(), allocator);
-    return result_body;
-  }
+  nanoarrow::UniqueBuffer GetBody();
 
  private:
   ClientProperties options;
   Allocator& allocator;
-  ArrowSchema* schema;
+  const ArrowSchema* schema{};
   unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
   nanoarrow::ipc::UniqueEncoder encoder;
   nanoarrow::UniqueArrayView chunk_view;

--- a/src/ipc/stream_factory.cpp
+++ b/src/ipc/stream_factory.cpp
@@ -1,23 +1,15 @@
 #include "ipc/stream_factory.hpp"
 
 #include <iostream>
+#include <utility>
 
 #include "ipc/stream_reader/ipc_buffer_stream_reader.hpp"
 #include "ipc/stream_reader/ipc_file_stream_reader.hpp"
 
 namespace duckdb {
 namespace ext_nanoarrow {
-ArrowIPCStreamFactory::ArrowIPCStreamFactory(ClientContext& context,
-                                             std::string src_string)
-    : fs(FileSystem::GetFileSystem(context)),
-      allocator(BufferAllocator::Get(context)),
-      src_string(std::move(src_string)) {}
-
-ArrowIPCStreamFactory::ArrowIPCStreamFactory(ClientContext& context,
-                                             vector<ArrowIPCBuffer> buffers)
-    : fs(FileSystem::GetFileSystem(context)),
-      allocator(BufferAllocator::Get(context)),
-      buffers(std::move(buffers)) {}
+ArrowIPCStreamFactory::ArrowIPCStreamFactory(Allocator& allocator_p)
+    : allocator(allocator_p) {}
 
 unique_ptr<ArrowArrayStreamWrapper> ArrowIPCStreamFactory::Produce(
     uintptr_t factory_ptr, ArrowStreamParameters& parameters) {
@@ -28,8 +20,7 @@ unique_ptr<ArrowArrayStreamWrapper> ArrowIPCStreamFactory::Produce(
     throw InternalException("IpcStreamReader was not initialized or was already moved");
   }
 
-  // FIXME: this is not excellent, IPC buffers should have same pushdown as file
-  if (!parameters.projected_columns.columns.empty() && factory->buffers.empty()) {
+  if (!parameters.projected_columns.columns.empty()) {
     factory->reader->SetColumnProjection(parameters.projected_columns.columns);
   }
 
@@ -47,19 +38,27 @@ void ArrowIPCStreamFactory::GetFileSchema(ArrowSchemaWrapper& schema) const {
       ArrowSchemaDeepCopy(reader->GetBaseSchema(), &schema.arrow_schema));
 }
 
-void ArrowIPCStreamFactory::InitReader() {
+BufferIPCStreamFactory::BufferIPCStreamFactory(ClientContext& context,
+                                               const vector<ArrowIPCBuffer>& buffers_p)
+    : ArrowIPCStreamFactory(BufferAllocator::Get(context)), buffers(buffers_p) {}
+
+void BufferIPCStreamFactory::InitReader() {
   if (reader) {
     throw InternalException("ArrowArrayStream or IpcStreamReader already initialized");
   }
-  // FIXME: bit hacky, clean this up
-  D_ASSERT(src_string.empty() || buffers.empty());
-  if (!src_string.empty()) {
-    unique_ptr<FileHandle> handle =
-        fs.OpenFile(src_string, FileOpenFlags::FILE_FLAGS_READ);
-    reader = make_uniq<IPCFileStreamReader>(fs, std::move(handle), allocator);
-  } else {
-    reader = make_uniq<IPCBufferStreamReader>(buffers, allocator);
+  reader = make_uniq<IPCBufferStreamReader>(buffers, allocator);
+}
+
+FileIPCStreamFactory::FileIPCStreamFactory(ClientContext& context, string src_string)
+    : ArrowIPCStreamFactory(BufferAllocator::Get(context)),
+      fs(FileSystem::GetFileSystem(context)),
+      src_string(std::move(src_string)) {}
+void FileIPCStreamFactory::InitReader() {
+  if (reader) {
+    throw InternalException("ArrowArrayStream or IpcStreamReader already initialized");
   }
+  unique_ptr<FileHandle> handle = fs.OpenFile(src_string, FileOpenFlags::FILE_FLAGS_READ);
+  reader = make_uniq<IPCFileStreamReader>(fs, std::move(handle), allocator);
 }
 
 }  // namespace ext_nanoarrow

--- a/src/scanner/read_arrow.cpp
+++ b/src/scanner/read_arrow.cpp
@@ -45,7 +45,7 @@ struct ReadArrowStream : ArrowTableFunction {
   // data (instead of as a Python object whose ownership is kept alive via the
   // DependencyItem mechanism).
   static TableFunction Function() {
-    TableFunction fn("read_arrow", {LogicalType::VARCHAR}, Scan, Bind,
+    TableFunction fn("read_arrow", {LogicalType::VARCHAR}, ArrowScanFunction, Bind,
                      ArrowScanInitGlobal, ArrowScanInitLocal);
     fn.cardinality = ArrowScanCardinality;
     fn.projection_pushdown = true;
@@ -95,7 +95,7 @@ struct ReadArrowStream : ArrowTableFunction {
   static unique_ptr<FunctionData> BindInternal(ClientContext& context, std::string src,
                                                vector<LogicalType>& return_types,
                                                vector<string>& names) {
-    auto stream_factory = make_uniq<ArrowIPCStreamFactory>(context, src);
+    auto stream_factory = make_uniq<FileIPCStreamFactory>(context, src);
     auto res = make_uniq<ArrowIPCFunctionData>(std::move(stream_factory));
     res->factory->InitReader();
     res->factory->GetFileSchema(res->schema_root);
@@ -111,11 +111,6 @@ struct ReadArrowStream : ArrowTableFunction {
     }
 
     return std::move(res);
-  }
-
-  static void Scan(ClientContext& context, TableFunctionInput& data_p,
-                   DataChunk& output) {
-    ArrowScanFunction(context, data_p, output);
   }
 };
 

--- a/src/writer/arrow_stream_writer.cpp
+++ b/src/writer/arrow_stream_writer.cpp
@@ -1,0 +1,88 @@
+#include "writer/arrow_stream_writer.hpp"
+namespace duckdb {
+
+namespace ext_nanoarrow {
+
+ArrowStreamWriter::ArrowStreamWriter(ClientContext& context, FileSystem& fs, const string& file_path,
+                    const vector<LogicalType>& logical_types,
+                    const vector<string>& column_names,
+                    const vector<pair<string, string>>& metadata)
+      : options(context.GetClientProperties()),
+        allocator(BufferAllocator::Get(context)),
+        serializer(options, allocator),
+        file_name(file_path),
+        logical_types(logical_types) {
+    InitSchema(logical_types, column_names, metadata);
+    InitOutputFile(fs, file_path);
+  }
+
+  void ArrowStreamWriter::InitSchema(const vector<LogicalType>& logical_types,
+                  const vector<string>& column_names,
+                  const vector<pair<string, string>>& metadata) {
+    nanoarrow::UniqueSchema tmp_schema;
+    ArrowConverter::ToArrowSchema(tmp_schema.get(), logical_types, column_names, options);
+
+    if (metadata.empty()) {
+      ArrowSchemaMove(tmp_schema.get(), schema.get());
+    } else {
+      nanoarrow::UniqueBuffer metadata_packed;
+      NANOARROW_THROW_NOT_OK(
+          ArrowMetadataBuilderInit(metadata_packed.get(), tmp_schema->metadata));
+      ArrowStringView key{};
+      ArrowStringView value{};
+      for (const auto& item : metadata) {
+        key = {item.first.data(), static_cast<int64_t>(item.first.size())};
+        value = {item.second.data(), static_cast<int64_t>(item.second.size())};
+        NANOARROW_THROW_NOT_OK(
+            ArrowMetadataBuilderAppend(metadata_packed.get(), key, value));
+      }
+
+      NANOARROW_THROW_NOT_OK(ArrowSchemaDeepCopy(tmp_schema.get(), schema.get()));
+      NANOARROW_THROW_NOT_OK(ArrowSchemaSetMetadata(
+          schema.get(), reinterpret_cast<char*>(metadata_packed->data)));
+    }
+
+    serializer.Init(schema.get(), logical_types);
+  }
+
+  void ArrowStreamWriter::InitOutputFile(FileSystem& fs, const string& file_path) {
+    writer = make_uniq<BufferedFileWriter>(
+        fs, file_path.c_str(),
+        FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+  }
+
+  void ArrowStreamWriter::WriteSchema() {
+    serializer.SerializeSchema();
+    serializer.Flush(*writer);
+  }
+
+  unique_ptr<ColumnDataCollectionSerializer> ArrowStreamWriter::NewSerializer() {
+    auto serializer = make_uniq<ColumnDataCollectionSerializer>(options, allocator);
+    serializer->Init(schema.get(), logical_types);
+    return serializer;
+  }
+
+  void ArrowStreamWriter::Flush(ColumnDataCollection& buffer) {
+    serializer.Serialize(buffer);
+    buffer.Reset();
+    serializer.Flush(*writer);
+    ++row_group_count;
+  }
+
+  void ArrowStreamWriter::Flush(ColumnDataCollectionSerializer& serializer) {
+    serializer.Flush(*writer);
+    ++row_group_count;
+  }
+
+  void ArrowStreamWriter::Finalize() const {
+    uint8_t end_of_stream[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00};
+    writer->WriteData(end_of_stream, sizeof(end_of_stream));
+    writer->Close();
+  }
+
+  idx_t ArrowStreamWriter::NumberOfRowGroups() const { return row_group_count; }
+
+  idx_t ArrowStreamWriter::FileSize() const { return writer->GetTotalWritten(); }
+
+}  // namespace ext_nanoarrow
+}  // namespace duckdb

--- a/src/writer/arrow_stream_writer.cpp
+++ b/src/writer/arrow_stream_writer.cpp
@@ -3,86 +3,87 @@ namespace duckdb {
 
 namespace ext_nanoarrow {
 
-ArrowStreamWriter::ArrowStreamWriter(ClientContext& context, FileSystem& fs, const string& file_path,
-                    const vector<LogicalType>& logical_types,
-                    const vector<string>& column_names,
-                    const vector<pair<string, string>>& metadata)
-      : options(context.GetClientProperties()),
-        allocator(BufferAllocator::Get(context)),
-        serializer(options, allocator),
-        file_name(file_path),
-        logical_types(logical_types) {
-    InitSchema(logical_types, column_names, metadata);
-    InitOutputFile(fs, file_path);
-  }
+ArrowStreamWriter::ArrowStreamWriter(ClientContext& context, FileSystem& fs,
+                                     const string& file_path,
+                                     const vector<LogicalType>& logical_types,
+                                     const vector<string>& column_names,
+                                     const vector<pair<string, string>>& metadata)
+    : options(context.GetClientProperties()),
+      allocator(BufferAllocator::Get(context)),
+      serializer(options, allocator),
+      file_name(file_path),
+      logical_types(logical_types) {
+  InitSchema(logical_types, column_names, metadata);
+  InitOutputFile(fs, file_path);
+}
 
-  void ArrowStreamWriter::InitSchema(const vector<LogicalType>& logical_types,
-                  const vector<string>& column_names,
-                  const vector<pair<string, string>>& metadata) {
-    nanoarrow::UniqueSchema tmp_schema;
-    ArrowConverter::ToArrowSchema(tmp_schema.get(), logical_types, column_names, options);
+void ArrowStreamWriter::InitSchema(const vector<LogicalType>& logical_types,
+                                   const vector<string>& column_names,
+                                   const vector<pair<string, string>>& metadata) {
+  nanoarrow::UniqueSchema tmp_schema;
+  ArrowConverter::ToArrowSchema(tmp_schema.get(), logical_types, column_names, options);
 
-    if (metadata.empty()) {
-      ArrowSchemaMove(tmp_schema.get(), schema.get());
-    } else {
-      nanoarrow::UniqueBuffer metadata_packed;
+  if (metadata.empty()) {
+    ArrowSchemaMove(tmp_schema.get(), schema.get());
+  } else {
+    nanoarrow::UniqueBuffer metadata_packed;
+    NANOARROW_THROW_NOT_OK(
+        ArrowMetadataBuilderInit(metadata_packed.get(), tmp_schema->metadata));
+    ArrowStringView key{};
+    ArrowStringView value{};
+    for (const auto& item : metadata) {
+      key = {item.first.data(), static_cast<int64_t>(item.first.size())};
+      value = {item.second.data(), static_cast<int64_t>(item.second.size())};
       NANOARROW_THROW_NOT_OK(
-          ArrowMetadataBuilderInit(metadata_packed.get(), tmp_schema->metadata));
-      ArrowStringView key{};
-      ArrowStringView value{};
-      for (const auto& item : metadata) {
-        key = {item.first.data(), static_cast<int64_t>(item.first.size())};
-        value = {item.second.data(), static_cast<int64_t>(item.second.size())};
-        NANOARROW_THROW_NOT_OK(
-            ArrowMetadataBuilderAppend(metadata_packed.get(), key, value));
-      }
-
-      NANOARROW_THROW_NOT_OK(ArrowSchemaDeepCopy(tmp_schema.get(), schema.get()));
-      NANOARROW_THROW_NOT_OK(ArrowSchemaSetMetadata(
-          schema.get(), reinterpret_cast<char*>(metadata_packed->data)));
+          ArrowMetadataBuilderAppend(metadata_packed.get(), key, value));
     }
 
-    serializer.Init(schema.get(), logical_types);
+    NANOARROW_THROW_NOT_OK(ArrowSchemaDeepCopy(tmp_schema.get(), schema.get()));
+    NANOARROW_THROW_NOT_OK(ArrowSchemaSetMetadata(
+        schema.get(), reinterpret_cast<char*>(metadata_packed->data)));
   }
 
-  void ArrowStreamWriter::InitOutputFile(FileSystem& fs, const string& file_path) {
-    writer = make_uniq<BufferedFileWriter>(
-        fs, file_path.c_str(),
-        FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  }
+  serializer.Init(schema.get(), logical_types);
+}
 
-  void ArrowStreamWriter::WriteSchema() {
-    serializer.SerializeSchema();
-    serializer.Flush(*writer);
-  }
+void ArrowStreamWriter::InitOutputFile(FileSystem& fs, const string& file_path) {
+  writer = make_uniq<BufferedFileWriter>(
+      fs, file_path.c_str(),
+      FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+}
 
-  unique_ptr<ColumnDataCollectionSerializer> ArrowStreamWriter::NewSerializer() {
-    auto serializer = make_uniq<ColumnDataCollectionSerializer>(options, allocator);
-    serializer->Init(schema.get(), logical_types);
-    return serializer;
-  }
+void ArrowStreamWriter::WriteSchema() {
+  serializer.SerializeSchema();
+  serializer.Flush(*writer);
+}
 
-  void ArrowStreamWriter::Flush(ColumnDataCollection& buffer) {
-    serializer.Serialize(buffer);
-    buffer.Reset();
-    serializer.Flush(*writer);
-    ++row_group_count;
-  }
+unique_ptr<ColumnDataCollectionSerializer> ArrowStreamWriter::NewSerializer() {
+  auto serializer = make_uniq<ColumnDataCollectionSerializer>(options, allocator);
+  serializer->Init(schema.get(), logical_types);
+  return serializer;
+}
 
-  void ArrowStreamWriter::Flush(ColumnDataCollectionSerializer& serializer) {
-    serializer.Flush(*writer);
-    ++row_group_count;
-  }
+void ArrowStreamWriter::Flush(ColumnDataCollection& buffer) {
+  serializer.Serialize(buffer);
+  buffer.Reset();
+  serializer.Flush(*writer);
+  ++row_group_count;
+}
 
-  void ArrowStreamWriter::Finalize() const {
-    uint8_t end_of_stream[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00};
-    writer->WriteData(end_of_stream, sizeof(end_of_stream));
-    writer->Close();
-  }
+void ArrowStreamWriter::Flush(ColumnDataCollectionSerializer& serializer) {
+  serializer.Flush(*writer);
+  ++row_group_count;
+}
 
-  idx_t ArrowStreamWriter::NumberOfRowGroups() const { return row_group_count; }
+void ArrowStreamWriter::Finalize() const {
+  uint8_t end_of_stream[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00};
+  writer->WriteData(end_of_stream, sizeof(end_of_stream));
+  writer->Close();
+}
 
-  idx_t ArrowStreamWriter::FileSize() const { return writer->GetTotalWritten(); }
+idx_t ArrowStreamWriter::NumberOfRowGroups() const { return row_group_count; }
+
+idx_t ArrowStreamWriter::FileSize() const { return writer->GetTotalWritten(); }
 
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/writer/column_data_collection_serializer.cpp
+++ b/src/writer/column_data_collection_serializer.cpp
@@ -1,0 +1,117 @@
+#include "writer/column_data_collection_serializer.hpp"
+
+#include <utility>
+namespace duckdb {
+
+namespace ext_nanoarrow {
+
+// Initialize buffer whose realloc operations go through DuckDB's memory
+// accounting. Note that the Allocator must outlive the buffer (true for
+// the case of this writer, but maybe not true for generic production of
+// ArrowArrays whose lifetime might outlive the connection/database).
+inline void InitArrowDuckBuffer(ArrowBuffer* buffer, Allocator& duck_allocator) {
+  ArrowBufferInit(buffer);
+
+  buffer->allocator.reallocate = [](ArrowBufferAllocator* allocator, uint8_t* ptr,
+                                    int64_t old_size, int64_t new_size) -> uint8_t* {
+    NANOARROW_DCHECK(allocator->private_data != nullptr);
+    auto duck_allocator = static_cast<Allocator*>(allocator->private_data);
+    if (ptr == nullptr && new_size > 0) {
+      return duck_allocator->AllocateData(new_size);
+    } else if (new_size == 0) {
+      duck_allocator->FreeData(ptr, old_size);
+      return nullptr;
+    } else {
+      return duck_allocator->ReallocateData(ptr, old_size, new_size);
+    }
+  };
+
+  buffer->allocator.free = [](ArrowBufferAllocator* allocator, uint8_t* ptr,
+                              int64_t old_size) {
+    NANOARROW_DCHECK(allocator->private_data != nullptr);
+    auto duck_allocator = static_cast<Allocator*>(allocator->private_data);
+    duck_allocator->FreeData(ptr, old_size);
+  };
+
+  buffer->allocator.private_data = &duck_allocator;
+}
+
+ ColumnDataCollectionSerializer::ColumnDataCollectionSerializer(
+    ClientProperties  options, Allocator& allocator)
+      : options(std::move(options)), allocator(allocator) {}
+
+  void ColumnDataCollectionSerializer::Init(const ArrowSchema* schema_p, const vector<LogicalType>& logical_types) {
+    InitArrowDuckBuffer(header.get(), allocator);
+    InitArrowDuckBuffer(body.get(), allocator);
+    NANOARROW_THROW_NOT_OK(ArrowIpcEncoderInit(encoder.get()));
+    THROW_NOT_OK(InternalException, &error,
+                 ArrowArrayViewInitFromSchema(chunk_view.get(), schema_p, &error));
+
+    schema = schema_p;
+
+    extension_types =
+        ArrowTypeExtensionData::GetExtensionTypes(*options.client_context, logical_types);
+  }
+
+  void ColumnDataCollectionSerializer::SerializeSchema() {
+    header->size_bytes = 0;
+    body->size_bytes = 0;
+    THROW_NOT_OK(InternalException, &error,
+                 ArrowIpcEncoderEncodeSchema(encoder.get(), schema, &error));
+    NANOARROW_THROW_NOT_OK(
+        ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+  }
+
+  idx_t ColumnDataCollectionSerializer::Serialize(DataChunk& chunk) {
+    header->size_bytes = 0;
+    body->size_bytes = 0;
+    chunk_arrow.reset();
+
+    ArrowConverter::ToArrowArray(chunk, chunk_arrow.get(), options, extension_types);
+    THROW_NOT_OK(duckdb::InternalException, &error,
+                 ArrowArrayViewSetArray(chunk_view.get(), chunk_arrow.get(), &error));
+    THROW_NOT_OK(InternalException, &error,
+                 ArrowIpcEncoderEncodeSimpleRecordBatch(encoder.get(), chunk_view.get(),
+                                                        body.get(), &error));
+    NANOARROW_THROW_NOT_OK(
+        ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+
+    return 1;
+  }
+
+  idx_t ColumnDataCollectionSerializer::Serialize(const ColumnDataCollection& buffer) {
+    header->size_bytes = 0;
+    body->size_bytes = 0;
+    if (buffer.Count() == 0) {
+      return 0;
+    }
+    // The ArrowConverter requires all of this to be in one big DataChunk.
+    // It would be better to append these one at a time using other DuckDB
+    // internals like the ArrowAppender. (Possibly better would be to skip the
+    // owning ArrowArray entirely and just expose an ArrowArrayView of the
+    // chunk. keeping track of any owning elements that had to be allocated,
+    // since that's all that is strictly required to write).
+    DataChunk chunk;
+    chunk.Initialize(allocator, buffer.Types(), buffer.Count());
+    for (const auto& item : buffer.Chunks()) {
+      chunk.Append(item, true);
+    }
+    return Serialize(chunk);
+  }
+
+  void ColumnDataCollectionSerializer::Flush(BufferedFileWriter& writer) {
+    writer.WriteData(header->data, header->size_bytes);
+    writer.WriteData(body->data, body->size_bytes);
+  }
+  nanoarrow::UniqueBuffer ColumnDataCollectionSerializer::GetHeader() {
+    auto result_header = std::move(header);
+    InitArrowDuckBuffer(header.get(), allocator);
+    return result_header;
+  }
+  nanoarrow::UniqueBuffer ColumnDataCollectionSerializer::GetBody() {
+    auto result_body = std::move(body);
+    InitArrowDuckBuffer(body.get(), allocator);
+    return result_body;
+  }
+}  // namespace ext_nanoarrow
+}  // namespace duckdb

--- a/src/writer/column_data_collection_serializer.cpp
+++ b/src/writer/column_data_collection_serializer.cpp
@@ -36,82 +36,97 @@ inline void InitArrowDuckBuffer(ArrowBuffer* buffer, Allocator& duck_allocator) 
   buffer->allocator.private_data = &duck_allocator;
 }
 
- ColumnDataCollectionSerializer::ColumnDataCollectionSerializer(
-    ClientProperties  options, Allocator& allocator)
-      : options(std::move(options)), allocator(allocator) {}
+ColumnDataCollectionSerializer::ColumnDataCollectionSerializer(ClientProperties options,
+                                                               Allocator& allocator)
+    : options(std::move(options)), allocator(allocator) {}
 
-  void ColumnDataCollectionSerializer::Init(const ArrowSchema* schema_p, const vector<LogicalType>& logical_types) {
-    InitArrowDuckBuffer(header.get(), allocator);
-    InitArrowDuckBuffer(body.get(), allocator);
-    NANOARROW_THROW_NOT_OK(ArrowIpcEncoderInit(encoder.get()));
-    THROW_NOT_OK(InternalException, &error,
-                 ArrowArrayViewInitFromSchema(chunk_view.get(), schema_p, &error));
+void ColumnDataCollectionSerializer::Init(const ArrowSchema* schema_p,
+                                          const vector<LogicalType>& logical_types) {
+  InitArrowDuckBuffer(header.get(), allocator);
+  InitArrowDuckBuffer(body.get(), allocator);
+  NANOARROW_THROW_NOT_OK(ArrowIpcEncoderInit(encoder.get()));
+  THROW_NOT_OK(InternalException, &error,
+               ArrowArrayViewInitFromSchema(chunk_view.get(), schema_p, &error));
 
-    schema = schema_p;
+  schema = schema_p;
 
-    extension_types =
-        ArrowTypeExtensionData::GetExtensionTypes(*options.client_context, logical_types);
+  extension_types =
+      ArrowTypeExtensionData::GetExtensionTypes(*options.client_context, logical_types);
+}
+
+void ColumnDataCollectionSerializer::SerializeSchema() {
+  header->size_bytes = 0;
+  body->size_bytes = 0;
+  THROW_NOT_OK(InternalException, &error,
+               ArrowIpcEncoderEncodeSchema(encoder.get(), schema, &error));
+  NANOARROW_THROW_NOT_OK(
+      ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+}
+
+idx_t ColumnDataCollectionSerializer::Serialize(ArrowArray& array) {
+  header->size_bytes = 0;
+  body->size_bytes = 0;
+
+  THROW_NOT_OK(duckdb::InternalException, &error,
+               ArrowArrayViewSetArray(chunk_view.get(), &array, &error));
+  THROW_NOT_OK(InternalException, &error,
+               ArrowIpcEncoderEncodeSimpleRecordBatch(encoder.get(), chunk_view.get(),
+                                                      body.get(), &error));
+  NANOARROW_THROW_NOT_OK(
+      ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+
+  return 1;
+}
+idx_t ColumnDataCollectionSerializer::Serialize(DataChunk& chunk) {
+  header->size_bytes = 0;
+  body->size_bytes = 0;
+  chunk_arrow.reset();
+
+  ArrowConverter::ToArrowArray(chunk, chunk_arrow.get(), options, extension_types);
+  THROW_NOT_OK(duckdb::InternalException, &error,
+               ArrowArrayViewSetArray(chunk_view.get(), chunk_arrow.get(), &error));
+  THROW_NOT_OK(InternalException, &error,
+               ArrowIpcEncoderEncodeSimpleRecordBatch(encoder.get(), chunk_view.get(),
+                                                      body.get(), &error));
+  NANOARROW_THROW_NOT_OK(
+      ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+
+  return 1;
+}
+
+idx_t ColumnDataCollectionSerializer::Serialize(const ColumnDataCollection& buffer) {
+  header->size_bytes = 0;
+  body->size_bytes = 0;
+  if (buffer.Count() == 0) {
+    return 0;
   }
-
-  void ColumnDataCollectionSerializer::SerializeSchema() {
-    header->size_bytes = 0;
-    body->size_bytes = 0;
-    THROW_NOT_OK(InternalException, &error,
-                 ArrowIpcEncoderEncodeSchema(encoder.get(), schema, &error));
-    NANOARROW_THROW_NOT_OK(
-        ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
+  // The ArrowConverter requires all of this to be in one big DataChunk.
+  // It would be better to append these one at a time using other DuckDB
+  // internals like the ArrowAppender. (Possibly better would be to skip the
+  // owning ArrowArray entirely and just expose an ArrowArrayView of the
+  // chunk. keeping track of any owning elements that had to be allocated,
+  // since that's all that is strictly required to write).
+  DataChunk chunk;
+  chunk.Initialize(allocator, buffer.Types(), buffer.Count());
+  for (const auto& item : buffer.Chunks()) {
+    chunk.Append(item, true);
   }
+  return Serialize(chunk);
+}
 
-  idx_t ColumnDataCollectionSerializer::Serialize(DataChunk& chunk) {
-    header->size_bytes = 0;
-    body->size_bytes = 0;
-    chunk_arrow.reset();
-
-    ArrowConverter::ToArrowArray(chunk, chunk_arrow.get(), options, extension_types);
-    THROW_NOT_OK(duckdb::InternalException, &error,
-                 ArrowArrayViewSetArray(chunk_view.get(), chunk_arrow.get(), &error));
-    THROW_NOT_OK(InternalException, &error,
-                 ArrowIpcEncoderEncodeSimpleRecordBatch(encoder.get(), chunk_view.get(),
-                                                        body.get(), &error));
-    NANOARROW_THROW_NOT_OK(
-        ArrowIpcEncoderFinalizeBuffer(encoder.get(), true, header.get()));
-
-    return 1;
-  }
-
-  idx_t ColumnDataCollectionSerializer::Serialize(const ColumnDataCollection& buffer) {
-    header->size_bytes = 0;
-    body->size_bytes = 0;
-    if (buffer.Count() == 0) {
-      return 0;
-    }
-    // The ArrowConverter requires all of this to be in one big DataChunk.
-    // It would be better to append these one at a time using other DuckDB
-    // internals like the ArrowAppender. (Possibly better would be to skip the
-    // owning ArrowArray entirely and just expose an ArrowArrayView of the
-    // chunk. keeping track of any owning elements that had to be allocated,
-    // since that's all that is strictly required to write).
-    DataChunk chunk;
-    chunk.Initialize(allocator, buffer.Types(), buffer.Count());
-    for (const auto& item : buffer.Chunks()) {
-      chunk.Append(item, true);
-    }
-    return Serialize(chunk);
-  }
-
-  void ColumnDataCollectionSerializer::Flush(BufferedFileWriter& writer) {
-    writer.WriteData(header->data, header->size_bytes);
-    writer.WriteData(body->data, body->size_bytes);
-  }
-  nanoarrow::UniqueBuffer ColumnDataCollectionSerializer::GetHeader() {
-    auto result_header = std::move(header);
-    InitArrowDuckBuffer(header.get(), allocator);
-    return result_header;
-  }
-  nanoarrow::UniqueBuffer ColumnDataCollectionSerializer::GetBody() {
-    auto result_body = std::move(body);
-    InitArrowDuckBuffer(body.get(), allocator);
-    return result_body;
-  }
+void ColumnDataCollectionSerializer::Flush(BufferedFileWriter& writer) {
+  writer.WriteData(header->data, header->size_bytes);
+  writer.WriteData(body->data, body->size_bytes);
+}
+nanoarrow::UniqueBuffer ColumnDataCollectionSerializer::GetHeader() {
+  auto result_header = std::move(header);
+  InitArrowDuckBuffer(header.get(), allocator);
+  return result_header;
+}
+nanoarrow::UniqueBuffer ColumnDataCollectionSerializer::GetBody() {
+  auto result_body = std::move(body);
+  InitArrowDuckBuffer(body.get(), allocator);
+  return result_body;
+}
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -110,7 +110,7 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
 
   bool sending_schema = false;
 
-  bool caching_disabled = PhysicalOperator::OperatorCachingAllowed(context);
+  bool caching_disabled = !PhysicalOperator::OperatorCachingAllowed(context);
   local_state.serializer->Init(&data.schema, data.logical_types);
 
   if (!local_state.checked_schema) {

--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -18,7 +18,7 @@ struct ToArrowIpcFunctionData : public TableFunctionData {
   ToArrowIpcFunctionData() = default;
   ArrowSchema schema{};
   vector<LogicalType> logical_types;
-  idx_t chunk_size{};
+  const idx_t chunk_size = ToArrowIPCFunction::DEFAULT_CHUNK_SIZE * STANDARD_VECTOR_SIZE;
 };
 
 struct ToArrowIpcGlobalState : public GlobalTableFunctionState {
@@ -28,7 +28,7 @@ struct ToArrowIpcGlobalState : public GlobalTableFunctionState {
 };
 
 struct ToArrowIpcLocalState : public LocalTableFunctionState {
-  // unique_ptr<ArrowAppender> appender;
+  unique_ptr<ArrowAppender> appender;
   unique_ptr<ColumnDataCollectionSerializer> serializer;
   idx_t current_count = 0;
   bool checked_schema = false;
@@ -55,8 +55,6 @@ unique_ptr<FunctionData> ToArrowIPCFunction::Bind(ClientContext& context,
                                                   vector<string>& names) {
   auto result = make_uniq<ToArrowIpcFunctionData>();
 
-  result->chunk_size = DEFAULT_CHUNK_SIZE * STANDARD_VECTOR_SIZE;
-
   // Set return schema
   return_types.emplace_back(LogicalType::BLOB);
   names.emplace_back("ipc");
@@ -71,6 +69,37 @@ unique_ptr<FunctionData> ToArrowIPCFunction::Bind(ClientContext& context,
   return std::move(result);
 }
 
+void SerializeArray(const ToArrowIpcLocalState& local_state,
+                    nanoarrow::UniqueBuffer& arrow_serialized_ipc_buffer) {
+  ArrowArray arr = local_state.appender->Finalize();
+  local_state.serializer->Serialize(arr);
+  arrow_serialized_ipc_buffer = local_state.serializer->GetHeader();
+  auto body = local_state.serializer->GetBody();
+  idx_t ipc_buffer_size = arrow_serialized_ipc_buffer->size_bytes;
+  arrow_serialized_ipc_buffer->data = arrow_serialized_ipc_buffer->allocator.reallocate(
+      &arrow_serialized_ipc_buffer->allocator, arrow_serialized_ipc_buffer->data,
+      static_cast<int64_t>(ipc_buffer_size),
+      static_cast<int64_t>(ipc_buffer_size + body->size_bytes));
+  arrow_serialized_ipc_buffer->size_bytes += body->size_bytes;
+  arrow_serialized_ipc_buffer->capacity_bytes += body->size_bytes;
+  memcpy(arrow_serialized_ipc_buffer->data + ipc_buffer_size, body->data,
+         body->size_bytes);
+}
+
+void InsertMessageToChunk(nanoarrow::UniqueBuffer& arrow_serialized_ipc_buffer,
+                          DataChunk& output) {
+  const auto ptr = reinterpret_cast<const char*>(arrow_serialized_ipc_buffer->data);
+  const auto len = arrow_serialized_ipc_buffer->size_bytes;
+  const auto wrapped_buffer =
+      make_buffer<ArrowStringVectorBuffer>(std::move(arrow_serialized_ipc_buffer));
+  auto& vector = output.data[0];
+  StringVector::AddBuffer(vector, wrapped_buffer);
+  const auto data_ptr = reinterpret_cast<string_t*>(vector.GetData());
+  *data_ptr = string_t(ptr, len);
+  output.SetCardinality(1);
+  output.Verify();
+}
+
 OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
                                                 TableFunctionInput& data_p,
                                                 DataChunk& input, DataChunk& output) {
@@ -81,7 +110,7 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
 
   bool sending_schema = false;
 
-  bool caching_disabled = !PhysicalOperator::OperatorCachingAllowed(context);
+  bool caching_disabled = PhysicalOperator::OperatorCachingAllowed(context);
   local_state.serializer->Init(&data.schema, data.logical_types);
 
   if (!local_state.checked_schema) {
@@ -102,66 +131,45 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
     arrow_serialized_ipc_buffer = local_state.serializer->GetHeader();
     output.data[1].SetValue(0, Value::BOOLEAN(true));
   } else {
-    // TODO The following code is necessary in the future to avoid creating a message per
-    // chunk: By using an appender that appends multiple chunks and serializes the whole
-    // thing if (!local_state.appender) {
-    //   local_state.appender = make_uniq<ArrowAppender>(input.GetTypes(),
-    //   data.chunk_size,
-    //                                context.client.GetClientProperties(),
-    //                                ArrowTypeExtensionData::GetExtensionTypes(
-    //                                    context.client, input.GetTypes()));
-    // }
+    if (!local_state.appender) {
+      local_state.appender = make_uniq<ArrowAppender>(
+          input.GetTypes(), data.chunk_size, context.client.GetClientProperties(),
+          ArrowTypeExtensionData::GetExtensionTypes(context.client, input.GetTypes()));
+    }
 
     // Append input chunk
-    // local_state.appender->Append(input, 0, input.size(), input.size());
+    local_state.appender->Append(input, 0, input.size(), input.size());
     local_state.current_count += input.size();
 
     // If chunk size is reached, we can flush to IPC blob
     if (caching_disabled || local_state.current_count >= data.chunk_size) {
-      // Construct record batch from DataChunk
-      // TODO The following code is necessary in the future to avoid creating a message
-      // per chunk:
-      // TODO  By using an appender that appends multiple chunks and serializes the whole
-      // thing
-
+      SerializeArray(local_state, arrow_serialized_ipc_buffer);
       // ArrowArray arr = local_state.appender->Finalize();
-      local_state.serializer->Serialize(input);
-      arrow_serialized_ipc_buffer = local_state.serializer->GetHeader();
-      auto body = local_state.serializer->GetBody();
-      idx_t ipc_buffer_size = arrow_serialized_ipc_buffer->size_bytes;
-      arrow_serialized_ipc_buffer->data =
-          arrow_serialized_ipc_buffer->allocator.reallocate(
-              &arrow_serialized_ipc_buffer->allocator, arrow_serialized_ipc_buffer->data,
-              static_cast<int64_t>(ipc_buffer_size), static_cast<int64_t>(ipc_buffer_size + body->size_bytes));
-      arrow_serialized_ipc_buffer->size_bytes += body->size_bytes;
-      arrow_serialized_ipc_buffer->capacity_bytes += body->size_bytes;
-      memcpy(arrow_serialized_ipc_buffer->data + ipc_buffer_size, body->data,
-             body->size_bytes);
-      // TODO The following code is necessary in the future to avoid creating a message
-      // per chunk:
-      // TODO By using an appender that appends multiple chunks and serializes the whole
-      // thing
+      // local_state.serializer->Serialize(arr);
+      // arrow_serialized_ipc_buffer = local_state.serializer->GetHeader();
+      // auto body = local_state.serializer->GetBody();
+      // idx_t ipc_buffer_size = arrow_serialized_ipc_buffer->size_bytes;
+      // arrow_serialized_ipc_buffer->data =
+      //     arrow_serialized_ipc_buffer->allocator.reallocate(
+      //         &arrow_serialized_ipc_buffer->allocator,
+      //         arrow_serialized_ipc_buffer->data, static_cast<int64_t>(ipc_buffer_size),
+      //         static_cast<int64_t>(ipc_buffer_size + body->size_bytes));
+      // arrow_serialized_ipc_buffer->size_bytes += body->size_bytes;
+      // arrow_serialized_ipc_buffer->capacity_bytes += body->size_bytes;
+      // memcpy(arrow_serialized_ipc_buffer->data + ipc_buffer_size, body->data,
+      //        body->size_bytes);
 
       // Reset appender
-      // local_state.appender.reset();
+      local_state.appender.reset();
       local_state.current_count = 0;
 
+      // This is a data message, hence we set the second column to false
       output.data[1].SetValue(0, Value::BOOLEAN(false));
     } else {
       return OperatorResultType::NEED_MORE_INPUT;
     }
   }
-
-  auto ptr = reinterpret_cast<const char*>(arrow_serialized_ipc_buffer->data);
-  auto len = arrow_serialized_ipc_buffer->size_bytes;
-  auto wrapped_buffer =
-      make_buffer<ArrowStringVectorBuffer>(std::move(arrow_serialized_ipc_buffer));
-  auto& vector = output.data[0];
-  StringVector::AddBuffer(vector, wrapped_buffer);
-  auto data_ptr = reinterpret_cast<string_t*>(vector.GetData());
-  *data_ptr = string_t(ptr, len);
-  output.SetCardinality(1);
-  output.Verify();
+  InsertMessageToChunk(arrow_serialized_ipc_buffer, output);
   if (sending_schema) {
     return OperatorResultType::HAVE_MORE_OUTPUT;
   } else {
@@ -172,32 +180,18 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
 OperatorFinalizeResultType ToArrowIPCFunction::FunctionFinal(ExecutionContext& context,
                                                              TableFunctionInput& data_p,
                                                              DataChunk& output) {
+  auto& local_state = data_p.local_state->Cast<ToArrowIpcLocalState>();
 
-  // auto &data = (ToArrowIpcFunctionData &)*data_p.bind_data;
-  // auto &local_state = (ToArrowIpcLocalState &)*data_p.local_state;
-  // std::shared_ptr<arrow::Buffer> arrow_serialized_ipc_buffer;
+  if (local_state.appender) {
+    // If we have an appender, we serialize the array into a message and insert it to the
+    // chunk
+    nanoarrow::UniqueBuffer arrow_serialized_ipc_buffer;
+    SerializeArray(local_state, arrow_serialized_ipc_buffer);
+    InsertMessageToChunk(arrow_serialized_ipc_buffer, output);
 
-  // if (local_state.appender) {
-  //   ArrowArray arr = local_state.appender->Finalize();
-  //   auto record_batch =
-  //       arrow::ImportRecordBatch(&arr, data.schema).ValueOrDie();
-  //
-  //   // Serialize recordbatch
-  //   auto options = arrow::ipc::IpcWriteOptions::Defaults();
-  //   auto result = arrow::ipc::SerializeRecordBatch(*record_batch, options);
-  //   arrow_serialized_ipc_buffer = result.ValueOrDie();
-  //
-  //   auto wrapped_buffer =
-  //       make_buffer<ArrowStringVectorBuffer>(arrow_serialized_ipc_buffer);
-  //   auto &vector = output.data[0];
-  //   StringVector::AddBuffer(vector, wrapped_buffer);
-  //   auto data_ptr = (string_t *)vector.GetData();
-  //   *data_ptr = string_t((const char *)arrow_serialized_ipc_buffer->data(),
-  //                        arrow_serialized_ipc_buffer->size());
-  //   output.SetCardinality(1);
-  //   local_state.appender.reset();
-  //   output.data[1].SetValue(0, Value::BOOLEAN(0));
-  // }
+    // This is always a data message, so we set the second column to false.
+    output.data[1].SetValue(0, Value::BOOLEAN(false));
+  }
 
   return OperatorFinalizeResultType::FINISHED;
 }

--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -144,21 +144,6 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
     // If chunk size is reached, we can flush to IPC blob
     if (caching_disabled || local_state.current_count >= data.chunk_size) {
       SerializeArray(local_state, arrow_serialized_ipc_buffer);
-      // ArrowArray arr = local_state.appender->Finalize();
-      // local_state.serializer->Serialize(arr);
-      // arrow_serialized_ipc_buffer = local_state.serializer->GetHeader();
-      // auto body = local_state.serializer->GetBody();
-      // idx_t ipc_buffer_size = arrow_serialized_ipc_buffer->size_bytes;
-      // arrow_serialized_ipc_buffer->data =
-      //     arrow_serialized_ipc_buffer->allocator.reallocate(
-      //         &arrow_serialized_ipc_buffer->allocator,
-      //         arrow_serialized_ipc_buffer->data, static_cast<int64_t>(ipc_buffer_size),
-      //         static_cast<int64_t>(ipc_buffer_size + body->size_bytes));
-      // arrow_serialized_ipc_buffer->size_bytes += body->size_bytes;
-      // arrow_serialized_ipc_buffer->capacity_bytes += body->size_bytes;
-      // memcpy(arrow_serialized_ipc_buffer->data + ipc_buffer_size, body->data,
-      //        body->size_bytes);
-
       // Reset appender
       local_state.appender.reset();
       local_state.current_count = 0;

--- a/src/writer/write_arrow_stream.cpp
+++ b/src/writer/write_arrow_stream.cpp
@@ -30,7 +30,7 @@ struct ArrowWriteBindData : public TableFunctionData {
   idx_t row_group_size = 122880;
   optional_idx row_groups_per_file;
   static constexpr const idx_t BYTES_PER_ROW = 1024;
-  idx_t row_group_size_bytes;
+  idx_t row_group_size_bytes{};
 };
 
 struct ArrowWriteGlobalState : public GlobalFunctionData {
@@ -83,7 +83,7 @@ unique_ptr<FunctionData> ArrowWriteBind(ClientContext& context,
       }
       auto values = StructValue::GetChildren(kv_struct);
       for (idx_t i = 0; i < values.size(); i++) {
-        auto value = values[i];
+        const auto& value = values[i];
         auto key = StructType::GetChildName(kv_struct_type, i);
         // If the value is a blob, write the raw blob bytes
         // otherwise, cast to string


### PR DESCRIPTION
This PR fixes the bullet points from https://github.com/paleolimbot/duckdb-nanoarrow/issues/2 With the exception of the Python Tests and the copy.

It also locks the builds for DuckDB v1.2
