### PR TITLE
Adding Python Tests + CI For Arrow IPC Buffers

### DIFF
--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -1,0 +1,42 @@
+on: [push, pull_request,repository_dispatch]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  python:
+    name: Python
+    runs-on: macos-latest
+    env:
+      GEN: ninja
+
+    steps:
+    - name: Install Ninja
+      run: brew install ninja
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Build DuckDB (Python)
+      run: |
+        cd duckdb/tools/pythonpkg
+        python3 -m pip install .
+
+    - name: Build Arrow Extension
+      run: make release
+
+    - name: Install Python Dependencies
+      shell: bash
+      run: |
+        pip install -r test/python/requirements-dev.txt
+
+    - name: Test Python
+      run: |
+        (cd test/python && python -m pytest)

--- a/src/include/ipc/stream_reader/ipc_buffer_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/ipc_buffer_stream_reader.hpp
@@ -25,6 +25,9 @@ class IPCBufferStreamReader final : public IPCStreamReader {
   vector<ArrowIPCBuffer> buffers;
   idx_t cur_idx = 0;
   idx_t cur_buffer_pos = 0;
+  data_ptr_t cur_buffer_ptr = nullptr;
+  int64_t cur_buffer_size = 0;
+  bool initialized = false;
 };
 
 }  // namespace ext_nanoarrow

--- a/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
+++ b/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
@@ -10,21 +10,31 @@ IPCBufferStreamReader::IPCBufferStreamReader(vector<ArrowIPCBuffer> buffers,
     : IPCStreamReader(allocator), buffers(std::move(buffers)) {}
 
 ArrowIpcMessageType IPCBufferStreamReader::ReadNextMessage() {
-  if (cur_idx >= buffers.size() || finished) {
+  if (!initialized && cur_idx == buffers.size() || finished) {
     finished = true;
     return NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED;
   }
-  cur_ptr = reinterpret_cast<data_ptr_t>(buffers[cur_idx].ptr);
-  cur_size = static_cast<int64_t>(buffers[cur_idx].size);
-  cur_buffer_pos = 0;
-  cur_idx++;
+
+  if (!initialized || cur_buffer_pos >= buffers[cur_idx].size) {
+    if (initialized) {
+      cur_idx++;
+    }
+    if (cur_idx >= buffers.size()) {
+      finished = true;
+      return NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED;
+    }
+    cur_buffer_ptr = reinterpret_cast<data_ptr_t>(buffers[cur_idx].ptr);
+    cur_buffer_size = static_cast<int64_t>(buffers[cur_idx].size);
+    cur_buffer_pos = 0;
+    initialized = true;
+  }
   ReadData(reinterpret_cast<data_ptr_t>(&message_prefix), sizeof(message_prefix));
   return DecodeMessage();
 }
 
 void IPCBufferStreamReader::ReadData(data_ptr_t ptr, idx_t size) {
-  D_ASSERT(size + cur_buffer_pos < cur_size);
-  memcpy(ptr, cur_ptr + cur_buffer_pos, size);
+  D_ASSERT(size + cur_buffer_pos < cur_buffer_size);
+  memcpy(ptr, cur_buffer_ptr + cur_buffer_pos, size);
   cur_buffer_pos += size;
 }
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,9 +1,5 @@
-import numpy
 import os
 import pytest
-import shutil
-from os.path import abspath
-import glob
 import duckdb
 from typing import Union, Optional
 from duckdb import DuckDBPyConnection
@@ -39,45 +35,3 @@ def require():
 def connection():
 	return add_extension('nanoarrow')
 
-@pytest.fixture(scope='session', autouse=True)
-def duckdb_cursor(request):
-    connection = duckdb.connect('')
-    cursor = connection.cursor()
-    cursor.execute('CREATE TABLE integers (i integer)')
-    cursor.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
-    cursor.execute('CREATE TABLE timestamps (t timestamp)')
-    cursor.execute("INSERT INTO timestamps VALUES ('1992-10-03 18:34:45'), ('2010-01-01 00:00:01'), (NULL)")
-    cursor.execute("CALL dbgen(sf=0.01)")
-    return cursor
-
-
-@pytest.fixture(scope="function")
-def duckdb_cursor_autocommit(request, tmp_path):
-    test_dbfarm = tmp_path.resolve().as_posix()
-
-    def finalizer():
-        duckdb.shutdown()
-        if tmp_path.is_dir():
-            shutil.rmtree(test_dbfarm)
-
-    request.addfinalizer(finalizer)
-
-    connection = duckdb.connect(test_dbfarm)
-    connection.set_autocommit(True)
-    cursor = connection.cursor()
-    return (cursor, connection, test_dbfarm)
-
-
-@pytest.fixture(scope="function")
-def initialize_duckdb(request, tmp_path):
-    test_dbfarm = tmp_path.resolve().as_posix()
-
-    def finalizer():
-        duckdb.shutdown()
-        if tmp_path.is_dir():
-            shutil.rmtree(test_dbfarm)
-
-    request.addfinalizer(finalizer)
-
-    duckdb.connect(test_dbfarm)
-    return test_dbfarm

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,83 @@
+import numpy
+import os
+import pytest
+import shutil
+from os.path import abspath
+import glob
+import duckdb
+from typing import Union, Optional
+from duckdb import DuckDBPyConnection
+
+dir = os.path.dirname(os.path.abspath(__file__))
+build_type = "release"
+
+@pytest.fixture(scope="function")
+def duckdb_empty_cursor(request):
+    connection = duckdb.connect('')
+    cursor = connection.cursor()
+    return cursor
+
+def add_extension(extension_name, conn: Union[str, DuckDBPyConnection] = '') -> DuckDBPyConnection:
+    if (isinstance(conn, str)):
+        config = {
+            'allow_unsigned_extensions' : 'true'
+        }
+        conn = duckdb.connect(conn or '', config=config)
+    file_path = f"'{dir}/../../build/{build_type}/extension/{extension_name}/{extension_name}.duckdb_extension'"
+    conn.execute(f"LOAD {file_path}")
+    return conn
+
+@pytest.fixture(scope="function")
+def require():
+    def _require(extension_name, db_name=''):
+        conn = add_extension(extension_name, db_name)
+        return conn
+
+    return _require
+
+@pytest.fixture(scope='function')
+def connection():
+	return add_extension('nanoarrow')
+
+@pytest.fixture(scope='session', autouse=True)
+def duckdb_cursor(request):
+    connection = duckdb.connect('')
+    cursor = connection.cursor()
+    cursor.execute('CREATE TABLE integers (i integer)')
+    cursor.execute('INSERT INTO integers VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(NULL)')
+    cursor.execute('CREATE TABLE timestamps (t timestamp)')
+    cursor.execute("INSERT INTO timestamps VALUES ('1992-10-03 18:34:45'), ('2010-01-01 00:00:01'), (NULL)")
+    cursor.execute("CALL dbgen(sf=0.01)")
+    return cursor
+
+
+@pytest.fixture(scope="function")
+def duckdb_cursor_autocommit(request, tmp_path):
+    test_dbfarm = tmp_path.resolve().as_posix()
+
+    def finalizer():
+        duckdb.shutdown()
+        if tmp_path.is_dir():
+            shutil.rmtree(test_dbfarm)
+
+    request.addfinalizer(finalizer)
+
+    connection = duckdb.connect(test_dbfarm)
+    connection.set_autocommit(True)
+    cursor = connection.cursor()
+    return (cursor, connection, test_dbfarm)
+
+
+@pytest.fixture(scope="function")
+def initialize_duckdb(request, tmp_path):
+    test_dbfarm = tmp_path.resolve().as_posix()
+
+    def finalizer():
+        duckdb.shutdown()
+        if tmp_path.is_dir():
+            shutil.rmtree(test_dbfarm)
+
+    request.addfinalizer(finalizer)
+
+    duckdb.connect(test_dbfarm)
+    return test_dbfarm

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -34,4 +34,3 @@ def require():
 @pytest.fixture(scope='function')
 def connection():
 	return add_extension('nanoarrow')
-

--- a/test/python/requirements-dev.txt
+++ b/test/python/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pyarrow

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -1,35 +1,53 @@
 import pytest
 import pyarrow as pa
 import duckdb
-import pyarrow.parquet as pq
+import pyarrow.ipc as ipc
 
 
-class TestArrowIPCBufferRead(object):
-   def test_single_batch(self, connection):
-      data = [
+def get_record_batch():
+   data = [
           pa.array([1, 2, 3, 4]),
           pa.array(['foo', 'bar', 'baz', None]),
           pa.array([True, None, False, True])
       ]
 
-      batch = pa.record_batch(data, names=['f0', 'f1', 'f2'])
+   return pa.record_batch(data, names=['f0', 'f1', 'f2'])
 
-      buffers = []
 
+class TestArrowIPCBufferRead(object):
+   def test_single_buffer(self, connection):
+      batch = get_record_batch()
       sink = pa.BufferOutputStream()
       with pa.ipc.new_stream(sink, batch.schema) as writer:
          for i in range(5):
             writer.write_batch(batch)
+      buffer = sink.getvalue()
+      struct =  f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}}"
+      arrow_scan_function = f"FROM scan_arrow_ipc([{struct}])"
 
-      buffers.append(sink.getvalue())
+      assert connection.execute(arrow_scan_function).fetchall() == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+
+   def test_multi_buffers(self, connection):
+      batch = get_record_batch()
+      sink = pa.BufferOutputStream()
+
+      with pa.ipc.new_stream(sink, batch.schema) as writer:
+          for _ in range(5):  # Write 5 batches into one stream
+              writer.write_batch(batch)
+
+      buffer = sink.getvalue()
+
+      buffers = []
+      with pa.BufferReader(buffer) as buf_reader:  # Use pyarrow.BufferReader
+          msg_reader = ipc.MessageReader.open_stream(buf_reader)
+          for message in msg_reader:
+              buffers.append(message.serialize())  # Serialize each message
 
       structs = ''
       for buffer in buffers:
           structs = structs + f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}},"
 
       structs = structs[:-1]
-      print(structs)
-
       arrow_scan_function = f"FROM scan_arrow_ipc([{structs}])"
-
-      connection.execute(arrow_scan_function).fetchall() == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+      assert (len(buffers) == 6)
+      assert connection.execute(arrow_scan_function).fetchall() == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -13,6 +13,8 @@ def get_record_batch():
 
    return pa.record_batch(data, names=['f0', 'f1', 'f2'])
 
+def tables_match(result):
+   assert result == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
 
 class TestArrowIPCBufferRead(object):
    def test_single_buffer(self, connection):
@@ -24,8 +26,8 @@ class TestArrowIPCBufferRead(object):
       buffer = sink.getvalue()
       struct =  f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}}"
       arrow_scan_function = f"FROM scan_arrow_ipc([{struct}])"
-
-      assert connection.execute(arrow_scan_function).fetchall() == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+      connection.execute(arrow_scan_function).fetchall()
+      tables_match(connection.execute(arrow_scan_function).fetchall())
 
    def test_multi_buffers(self, connection):
       batch = get_record_batch()
@@ -50,4 +52,4 @@ class TestArrowIPCBufferRead(object):
       structs = structs[:-1]
       arrow_scan_function = f"FROM scan_arrow_ipc([{structs}])"
       assert (len(buffers) == 6)
-      assert connection.execute(arrow_scan_function).fetchall() == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+      tables_match(connection.execute(arrow_scan_function).fetchall())

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -1,0 +1,38 @@
+import pyarrow as pa
+import duckdb
+import pyarrow.parquet as pq
+
+
+con = duckdb.connect(config={"allow_unsigned_extensions":"true"})
+
+# con.execute("load 'arrow'")
+
+con.execute("load '/Users/holanda/Documents/Projects/duckdb-arrow/build/release/extension/nanoarrow/nanoarrow.duckdb_extension'")
+
+data = [
+    pa.array([1, 2, 3, 4]),
+    pa.array(['foo', 'bar', 'baz', None]),
+    pa.array([True, None, False, True])
+]
+
+batch = pa.record_batch(data, names=['f0', 'f1', 'f2'])
+
+buffers = []
+
+sink = pa.BufferOutputStream()
+with pa.ipc.new_stream(sink, batch.schema) as writer:
+   for i in range(5):
+      writer.write_batch(batch)
+
+buffers.append(sink.getvalue())
+
+structs = ''
+for buffer in buffers:
+    structs = structs + f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}},"
+
+structs = structs[:-1]
+print(structs)
+
+arrow_scan_function = f"FROM scan_arrow_ipc([{structs}])"
+
+print(con.execute(arrow_scan_function).fetchall())

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -1,38 +1,35 @@
+import pytest
 import pyarrow as pa
 import duckdb
 import pyarrow.parquet as pq
 
 
-con = duckdb.connect(config={"allow_unsigned_extensions":"true"})
+class TestArrowIPCBufferRead(object):
+   def test_single_batch(self, connection):
+      data = [
+          pa.array([1, 2, 3, 4]),
+          pa.array(['foo', 'bar', 'baz', None]),
+          pa.array([True, None, False, True])
+      ]
 
-# con.execute("load 'arrow'")
+      batch = pa.record_batch(data, names=['f0', 'f1', 'f2'])
 
-con.execute("load '/Users/holanda/Documents/Projects/duckdb-arrow/build/release/extension/nanoarrow/nanoarrow.duckdb_extension'")
+      buffers = []
 
-data = [
-    pa.array([1, 2, 3, 4]),
-    pa.array(['foo', 'bar', 'baz', None]),
-    pa.array([True, None, False, True])
-]
+      sink = pa.BufferOutputStream()
+      with pa.ipc.new_stream(sink, batch.schema) as writer:
+         for i in range(5):
+            writer.write_batch(batch)
 
-batch = pa.record_batch(data, names=['f0', 'f1', 'f2'])
+      buffers.append(sink.getvalue())
 
-buffers = []
+      structs = ''
+      for buffer in buffers:
+          structs = structs + f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}},"
 
-sink = pa.BufferOutputStream()
-with pa.ipc.new_stream(sink, batch.schema) as writer:
-   for i in range(5):
-      writer.write_batch(batch)
+      structs = structs[:-1]
+      print(structs)
 
-buffers.append(sink.getvalue())
+      arrow_scan_function = f"FROM scan_arrow_ipc([{structs}])"
 
-structs = ''
-for buffer in buffers:
-    structs = structs + f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}},"
-
-structs = structs[:-1]
-print(structs)
-
-arrow_scan_function = f"FROM scan_arrow_ipc([{structs}])"
-
-print(con.execute(arrow_scan_function).fetchall())
+      connection.execute(arrow_scan_function).fetchall() == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]

--- a/test/python/test_arrow_ipc_writer.py
+++ b/test/python/test_arrow_ipc_writer.py
@@ -1,0 +1,45 @@
+import pytest
+import pyarrow as pa
+import duckdb
+import pyarrow.ipc as ipc
+
+def create_table(connection):
+	connection.execute("CREATE TABLE T (f0 integer, f1 varchar, f2 bool )")
+	connection.execute("INSERT INTO T values (1, 'foo', true),(2, 'bar', NULL), (3, 'baz', false), (4, NULL, true) ")
+
+def tables_match(result):
+	print(result)
+	assert result == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+
+class TestArrowIPCBufferWriter(object):
+	def test_round_trip(self, connection):
+		create_table(connection)
+		buffers = connection.execute("FROM to_arrow_ipc((FROM T))").fetchall()
+		arrow_buffers = []
+		for buffer in buffers:
+			arrow_buffers.append(pa.py_buffer(buffer[0]))
+		structs = ''
+		for buffer in arrow_buffers:
+			structs = structs + f"{{'ptr': {buffer.address}::UBIGINT, 'size': {buffer.size}::UBIGINT}},"
+
+		structs = structs[:-1]
+		arrow_scan_function = f"FROM scan_arrow_ipc([{structs}])"
+		assert (len(arrow_buffers) == 2)
+		print(arrow_buffers)
+		tables_match(connection.execute(arrow_scan_function).fetchall())
+
+	def test_arrow_read_duck_buffers(self, connection):
+		create_table(connection)
+		buffers = connection.execute("FROM to_arrow_ipc((FROM T))").fetchall()
+		arrow_buffers = []
+		# We have to concatenate the schema to the data
+		arrow_buffers.append(pa.py_buffer(buffers[0][0] + buffers[1][0]))
+		assert buffers[0][1] == True
+		assert buffers[1][1] == False
+		batches = []
+		with pa.BufferReader(arrow_buffers[0]) as reader:
+			stream_reader = ipc.RecordBatchStreamReader(reader)
+			schema = stream_reader.schema
+			batches.extend(stream_reader)
+		arrow_table = pa.Table.from_batches(batches, schema=schema)
+		tables_match(connection.execute("FROM arrow_table").fetchall())


### PR DESCRIPTION
This PR introduces basic Python tests for the to_arrow_ipc and scan_arrow_ipc in-out table functions, so we can refrain from writing tests in JavaScript in the future, since the python infrastructure is already there :-).

The tests are somewhat basic but cover DuckDB’s consumption of single and multi-buffers produced by PyArrow. They also verify that DuckDB can roundtrip its IPC buffers and that PyArrow can correctly consume buffers produced by DuckDB.

Additionally, this PR includes the CI setup for running the Python tests.

While writing these tests, I also found a bug, which is fixed in this PR.

Partially fixes: https://github.com/paleolimbot/duckdb-nanoarrow/issues/2


