### PR TITLE
Zero copy IPC Buffers

### DIFF
--- a/src/include/ipc/stream_reader/base_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/base_stream_reader.hpp
@@ -66,17 +66,13 @@ class IPCStreamReader {
   }
 
  protected:
-  virtual void EnsureInputStreamAligned() {
-    //! nop by default. This method is called in the DecodeMessage() and necessary only
-    //! for the file reader, for the buffer reader it does nothing.
-  }
   virtual data_ptr_t ReadData(data_ptr_t ptr, idx_t size) {
     throw InternalException("IPCStreamReader::ReadData not implemented");
   }
   //! Decode Message is composed of 3 steps
   ArrowIpcMessageType DecodeMessage();
   //! 1. We decode the message metadata, and return the message_header_size
-  idx_t DecodeMetadata();
+  idx_t DecodeMetadata() const;
   //! 2. We decode the message head, if message is finished we return true
   virtual bool DecodeHeader(idx_t message_header_size) {
     throw InternalException("IPCStreamReader::DecodeHead not implemented");

--- a/src/include/ipc/stream_reader/ipc_buffer_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/ipc_buffer_stream_reader.hpp
@@ -21,7 +21,7 @@ class IPCBufferStreamReader final : public IPCStreamReader {
   ArrowIpcMessageType ReadNextMessage() override;
 
  private:
-  void ReadData(data_ptr_t ptr, idx_t size) override;
+  data_ptr_t ReadData(data_ptr_t ptr, idx_t size) override;
   vector<ArrowIPCBuffer> buffers;
   idx_t cur_idx = 0;
   idx_t cur_buffer_pos = 0;

--- a/src/include/ipc/stream_reader/ipc_buffer_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/ipc_buffer_stream_reader.hpp
@@ -13,6 +13,12 @@
 namespace duckdb {
 namespace ext_nanoarrow {
 
+struct IPCBuffer {
+  idx_t pos = 0;
+  data_ptr_t ptr = nullptr;
+  int64_t size = 0;
+};
+
 //! Buffer Stream
 class IPCBufferStreamReader final : public IPCStreamReader {
  public:
@@ -22,11 +28,14 @@ class IPCBufferStreamReader final : public IPCStreamReader {
 
  private:
   data_ptr_t ReadData(data_ptr_t ptr, idx_t size) override;
+  bool DecodeHeader(idx_t message_header_size) override;
+  void DecodeBody() override;
+  nanoarrow::UniqueBuffer GetUniqueBuffer() override;
   vector<ArrowIPCBuffer> buffers;
   idx_t cur_idx = 0;
-  idx_t cur_buffer_pos = 0;
-  data_ptr_t cur_buffer_ptr = nullptr;
-  int64_t cur_buffer_size = 0;
+  IPCBuffer header;
+  IPCBuffer body;
+  IPCBuffer cur_buffer;
   bool initialized = false;
 };
 

--- a/src/include/ipc/stream_reader/ipc_file_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/ipc_file_stream_reader.hpp
@@ -28,7 +28,7 @@ class IPCFileStreamReader final : public IPCStreamReader {
   AllocatedData message_header;
   shared_ptr<AllocatedData> message_body;
 
-  void EnsureInputStreamAligned() override;
+  void EnsureInputStreamAligned();
 
   data_ptr_t ReadData(data_ptr_t ptr, idx_t size) override;
   static void DecodeArray(nanoarrow::ipc::UniqueDecoder& decoder, ArrowArray* out,

--- a/src/include/ipc/stream_reader/ipc_file_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/ipc_file_stream_reader.hpp
@@ -25,13 +25,17 @@ class IPCFileStreamReader final : public IPCStreamReader {
   static constexpr uint32_t kContinuationToken = 0xFFFFFFFF;
 
   BufferedFileReader file_reader;
+  AllocatedData message_header;
+  shared_ptr<AllocatedData> message_body;
 
   void EnsureInputStreamAligned() override;
 
-  void ReadData(data_ptr_t ptr, idx_t size) override;
+  data_ptr_t ReadData(data_ptr_t ptr, idx_t size) override;
   static void DecodeArray(nanoarrow::ipc::UniqueDecoder& decoder, ArrowArray* out,
                           ArrowBufferView& body_view, ArrowError* error);
-
+  bool DecodeHeader(idx_t message_header_size) override;
+  void DecodeBody() override;
+  nanoarrow::UniqueBuffer GetUniqueBuffer() override;
   void PopulateNames(vector<string>& names);
 };
 

--- a/src/ipc/stream_reader/base_stream_reader.cpp
+++ b/src/ipc/stream_reader/base_stream_reader.cpp
@@ -210,7 +210,7 @@ void IPCStreamReader::SetColumnProjection(const vector<string>& column_names) {
   projected_schema = std::move(schema);
 }
 
-idx_t IPCStreamReader::DecodeMetadata() {
+idx_t IPCStreamReader::DecodeMetadata() const {
   idx_t metadata_size;
   if (!Radix::IsLittleEndian()) {
     metadata_size = static_cast<int32_t>(BSWAP32(message_prefix.metadata_size));
@@ -222,7 +222,6 @@ idx_t IPCStreamReader::DecodeMetadata() {
     throw IOException(std::string("Expected metadata size >= 0 but got " +
                                   std::to_string(metadata_size)));
   }
-  // Ensure we have enough space to read the header
   return metadata_size + sizeof(message_prefix);
 }
 

--- a/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
+++ b/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
@@ -10,7 +10,7 @@ IPCBufferStreamReader::IPCBufferStreamReader(vector<ArrowIPCBuffer> buffers,
     : IPCStreamReader(allocator), buffers(std::move(buffers)) {}
 
 ArrowIpcMessageType IPCBufferStreamReader::ReadNextMessage() {
-  if (!initialized && cur_idx == buffers.size() || finished) {
+  if ((!initialized && cur_idx == buffers.size()) || finished) {
     finished = true;
     return NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED;
   }
@@ -32,10 +32,12 @@ ArrowIpcMessageType IPCBufferStreamReader::ReadNextMessage() {
   return DecodeMessage();
 }
 
-void IPCBufferStreamReader::ReadData(data_ptr_t ptr, idx_t size) {
+data_ptr_t IPCBufferStreamReader::ReadData(data_ptr_t ptr, idx_t size) {
   D_ASSERT(size + cur_buffer_pos < cur_buffer_size);
-  memcpy(ptr, cur_buffer_ptr + cur_buffer_pos, size);
+  data_ptr_t cur_ptr = cur_buffer_ptr + cur_buffer_pos;
+  // memcpy(ptr, cur_buffer_ptr + cur_buffer_pos, size);
   cur_buffer_pos += size;
+  return cur_ptr;
 }
 
 }  // namespace ext_nanoarrow

--- a/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
+++ b/src/ipc/stream_reader/ipc_buffer_stream_reader.cpp
@@ -14,8 +14,7 @@ ArrowIpcMessageType IPCBufferStreamReader::ReadNextMessage() {
     finished = true;
     return NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED;
   }
-
-  if (!initialized || cur_buffer_pos >= buffers[cur_idx].size) {
+  if (!initialized || cur_buffer.pos >= buffers[cur_idx].size) {
     if (initialized) {
       cur_idx++;
     }
@@ -23,21 +22,56 @@ ArrowIpcMessageType IPCBufferStreamReader::ReadNextMessage() {
       finished = true;
       return NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED;
     }
-    cur_buffer_ptr = reinterpret_cast<data_ptr_t>(buffers[cur_idx].ptr);
-    cur_buffer_size = static_cast<int64_t>(buffers[cur_idx].size);
-    cur_buffer_pos = 0;
+    cur_buffer.ptr = reinterpret_cast<data_ptr_t>(buffers[cur_idx].ptr);
+    cur_buffer.size = static_cast<int64_t>(buffers[cur_idx].size);
+    cur_buffer.pos = 0;
     initialized = true;
   }
-  ReadData(reinterpret_cast<data_ptr_t>(&message_prefix), sizeof(message_prefix));
+  auto* message_prefix_ptr = reinterpret_cast<const ArrowIpcMessagePrefix*>(
+      ReadData(reinterpret_cast<data_ptr_t>(&message_prefix), sizeof(message_prefix)));
+  message_prefix = *message_prefix_ptr;
   return DecodeMessage();
 }
 
 data_ptr_t IPCBufferStreamReader::ReadData(data_ptr_t ptr, idx_t size) {
-  D_ASSERT(size + cur_buffer_pos < cur_buffer_size);
-  data_ptr_t cur_ptr = cur_buffer_ptr + cur_buffer_pos;
-  // memcpy(ptr, cur_buffer_ptr + cur_buffer_pos, size);
-  cur_buffer_pos += size;
+  D_ASSERT(size + cur_buffer.pos < cur_buffer.size);
+  data_ptr_t cur_ptr = cur_buffer.ptr + cur_buffer.pos;
+  cur_buffer.pos += size;
   return cur_ptr;
+}
+
+bool IPCBufferStreamReader::DecodeHeader(idx_t message_header_size) {
+  // Our Header must contain the message prefix
+  header.ptr =
+      ReadData(header.ptr, message_prefix.metadata_size) - sizeof(message_prefix);
+  header.size = message_header_size;
+  const ArrowErrorCode decode_header_status = ArrowIpcDecoderDecodeHeader(
+      decoder.get(), AllocatedDataView(header.ptr, header.size), &error);
+  if (decode_header_status == ENODATA) {
+    finished = true;
+    return true;
+  }
+  THROW_NOT_OK(IOException, &error, decode_header_status);
+  return false;
+}
+
+void IPCBufferStreamReader::DecodeBody() {
+  if (decoder->body_size_bytes > 0) {
+    body.ptr = ReadData(body.ptr, decoder->body_size_bytes);
+  }
+  if (body.ptr) {
+    cur_ptr = body.ptr;
+    cur_size = body.size;
+  } else {
+    cur_ptr = nullptr;
+    cur_size = 0;
+  }
+}
+
+nanoarrow::UniqueBuffer IPCBufferStreamReader::GetUniqueBuffer() {
+  nanoarrow::UniqueBuffer out;
+  nanoarrow::BufferInitWrapped(out.get(), body, body.ptr, body.size);
+  return out;
 }
 
 }  // namespace ext_nanoarrow

--- a/src/ipc/stream_reader/ipc_file_stream_reader.cpp
+++ b/src/ipc/stream_reader/ipc_file_stream_reader.cpp
@@ -33,8 +33,56 @@ void IPCFileStreamReader::DecodeArray(nanoarrow::ipc::UniqueDecoder& decoder,
   ArrowArrayMove(array.get(), out);
 }
 
-void IPCFileStreamReader::ReadData(data_ptr_t ptr, idx_t size) {
+nanoarrow::UniqueBuffer IPCFileStreamReader::GetUniqueBuffer() {
+  return AllocatedDataToOwningBuffer(message_body);
+}
+bool IPCFileStreamReader::DecodeHeader(const idx_t message_header_size) {
+  if (message_header.GetSize() < message_header_size) {
+    message_header = allocator.Allocate(message_header_size);
+  }
+  // Read the message header. I believe the fact that this loops and calls
+  // the file handle's Read() method with relatively small chunks will ensure that
+  // an attempt to read a very large message_header_size can be cancelled. If this
+  // is not the case, we might want to implement our own buffering.
+  std::memcpy(message_header.get(), &message_prefix, sizeof(message_prefix));
+  ReadData(message_header.get() + sizeof(message_prefix), message_prefix.metadata_size);
+
+  ArrowErrorCode decode_header_status = ArrowIpcDecoderDecodeHeader(
+      decoder.get(),
+      AllocatedDataView(message_header.get(),
+                        static_cast<int64_t>(message_header.GetSize())),
+      &error);
+  if (decode_header_status == ENODATA) {
+    finished = true;
+    return true;
+  }
+  THROW_NOT_OK(IOException, &error, decode_header_status);
+  return false;
+}
+
+void IPCFileStreamReader::DecodeBody() {
+  if (decoder->body_size_bytes > 0) {
+    EnsureInputStreamAligned();
+    message_body =
+        make_shared_ptr<AllocatedData>(allocator.Allocate(decoder->body_size_bytes));
+
+    // Again, this is possibly a long running Read() call for a large body.
+    // We could possibly be smarter about how we do this, particularly if we
+    // are reading a small portion of the input from a seekable file.
+    ReadData(message_body->get(), decoder->body_size_bytes);
+  }
+  if (message_body) {
+    cur_ptr = message_body->get();
+    cur_size = static_cast<int64_t>(message_body->GetSize());
+  } else {
+    cur_ptr = nullptr;
+    cur_size = 0;
+  }
+}
+
+data_ptr_t IPCFileStreamReader::ReadData(data_ptr_t ptr, idx_t size) {
   file_reader.ReadData(ptr, size);
+  return ptr;
 }
 
 ArrowIpcMessageType IPCFileStreamReader::ReadNextMessage() {
@@ -52,7 +100,6 @@ ArrowIpcMessageType IPCFileStreamReader::ReadNextMessage() {
     finished = true;
     return NANOARROW_IPC_MESSAGE_TYPE_UNINITIALIZED;
   }
-
   // If we're at the beginning of the read, and we see the Arrow file format
   // header bytes, skip them and try to read the stream anyway. This works because
   // there's a full stream within an Arrow file (including the EOS indicator, which


### PR DESCRIPTION
This PR generalizes the decoding interface between the Arrow IPC File/Buffer scanners to avoid copying buffers.
Since these buffers are streamed by a producer that must remain alive during execution, I believe releasing the buffers is not the consumer's responsibility—is that correct?
Otherwise, we would need to modify the buffer scan interface to include a release callback as well.

This improved https://github.com/paleolimbot/duckdb-nanoarrow/pull/7 to ~0.48s. The remainder of the time consists of the allocation of decoded buffers, decoding costs, and other factors.