### PR TITLE
Have a stable duckdb branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,11 +20,11 @@ jobs:
       ci_tools_version: main
       extension_name: nanoarrow
 
-# FIXME: We should have a stable branch where this is executed, for bug-fixes that are not dependent of DuckDB
-#  duckdb-stable-build:
-#    name: Build extension binaries
-#    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.0
-#    with:
-#      duckdb_version: v1.2.0
-#      ci_tools_version: v1.2.0
-#      extension_name: nanoarrow
+  duckdb-stable-build:
+    name: Build extension binaries
+    if: github.ref == 'refs/heads/stable'
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.1
+    with:
+      duckdb_version: v1.2.1
+      ci_tools_version: v1.2.1
+      extension_name: nanoarrow

--- a/.github/workflows/NodeJS.yml
+++ b/.github/workflows/NodeJS.yml
@@ -6,7 +6,7 @@ defaults:
 
 jobs:
   nodejs:
-    if: false  # This prevents the job from running, we need to re-tag this before release (sudo npm i duckdb@1.3). This is due to an incompatibility of the extension with v1.2, since it depends on functionality of v1.3
+    if: github.ref == 'refs/heads/stable'
     name: NodeJS
     runs-on: macos-latest
     env:
@@ -40,7 +40,7 @@ jobs:
       - name: Build duckdb
         run: |
           cd duckdb
-          git checkout 8e52ec43959ab363643d63cb78ee214577111da4
+          git checkout 8e52ec43959ab363643d63cb78ee214577111da4 #v1.2.1
           cd ..
           make
 


### PR DESCRIPTION
This PR ensures that the CI which depends on a stable version of DuckDB is only executed on the `stable` branch.

This will allow us to make releases from the `stable` branch, while the `main` branch can depend on core changes that are part of future DuckDB releases.

In practice, any changes that are independent of core/client changes should be merged into `stable`, and then bubbled up to `main`.

If a change requires modifications to the core/clients, it should go into `main`.

We should then only release new versions from the `stable` branch.

Fix:https://github.com/paleolimbot/duckdb-nanoarrow/issues/19