### PR TITLE
README: fix read_arrow_stream => read_arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LOAD nanoarrow;
 SELECT
     commit, message
   FROM
-    read_arrow_stream('https://github.com/apache/arrow-experiments/raw/refs/heads/main/data/arrow-commits/arrow-commits.arrows')
+    read_arrow('https://github.com/apache/arrow-experiments/raw/refs/heads/main/data/arrow-commits/arrow-commits.arrows')
   LIMIT 10;
 ```
 


### PR DESCRIPTION
Hello,

I believe the README is misguiding by documenting that the function is called `read_arrow_stream` where in fact it is `read_arrow`.

Let me know if I'm mistaken.