### PR TITLE
Prepare for V1.4 andium

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -22,7 +22,7 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    if: github.ref == 'refs/heads/stable'
+    if: false # Disabled because we are now in `v1.4-andium` branch that will be incompatible with latest stable release
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.1
     with:
       duckdb_version: v1.2.1

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: duckdb/duckdb-python
+        path: duckdb-python
         fetch-depth: 0
         submodules: true
 

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -24,11 +24,26 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Build DuckDB (Python)
+    - name: Checkout DuckDB Python
+      uses: actions/checkout@v4
+      with:
+        repository: duckdb/duckdb-python
+        fetch-depth: 0
+        submodules: true
+
+    - name: Checkout DuckDB
+      shell: bash
       run: |
         cd duckdb
+        git fetch origin
         git checkout main
-        cd tools/pythonpkg
+        cd ../duckdb-python/external/duckdb
+        git fetch origin
+        git checkout main
+
+    - name: Build DuckDB (Python)
+      run: |
+        cd duckdb-python
         python3 -m pip install .
 
     - name: Build Arrow Extension

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/python/__pycache__/
 .Rhistory
 .vscode/settings.json
 .cache
+duckdb-python

--- a/src/file_scanner/arrow_file_scan.cpp
+++ b/src/file_scanner/arrow_file_scan.cpp
@@ -14,8 +14,8 @@ ArrowFileScan::ArrowFileScan(ClientContext& context, const string& file_name)
   factory->InitReader();
   factory->GetFileSchema(schema_root);
   DBConfig& config = DatabaseInstance::GetDatabase(context).config;
-  ArrowTableFunction::PopulateArrowTableSchema(
-    config, arrow_table, schema_root.arrow_schema);
+  ArrowTableFunction::PopulateArrowTableSchema(config, arrow_table,
+                                               schema_root.arrow_schema);
   names = arrow_table.GetNames();
   types = arrow_table.GetTypes();
   if (types.empty()) {

--- a/src/file_scanner/arrow_multi_file_info.cpp
+++ b/src/file_scanner/arrow_multi_file_info.cpp
@@ -23,8 +23,8 @@ bool ArrowMultiFileInfo::ParseCopyOption(ClientContext& context, const string& k
   return false;
 }
 
-unique_ptr<MultiFileReaderInterface> ArrowMultiFileInfo::InitializeInterface(
-    ClientContext& context, MultiFileReader& reader, MultiFileList& file_list) {
+unique_ptr<MultiFileReaderInterface> ArrowMultiFileInfo::CreateInterface(
+    ClientContext& context) {
   return make_uniq<ArrowMultiFileInfo>();
 }
 

--- a/src/include/file_scanner/arrow_file_scan.hpp
+++ b/src/include/file_scanner/arrow_file_scan.hpp
@@ -32,7 +32,7 @@ class ArrowFileScan : public BaseFileReader {
   const vector<string>& GetNames();
   const vector<LogicalType>& GetTypes();
   ArrowSchemaWrapper schema_root;
-  ArrowTableType arrow_table_type;
+  ArrowTableSchema arrow_table;
 
   bool TryInitializeScan(ClientContext& context, GlobalTableFunctionState& gstate,
                          LocalTableFunctionState& lstate) override;

--- a/src/include/file_scanner/arrow_multi_file_info.hpp
+++ b/src/include/file_scanner/arrow_multi_file_info.hpp
@@ -56,8 +56,7 @@ struct ArrowMultiFileInfo : MultiFileReaderInterface {
   unique_ptr<BaseFileReaderOptions> InitializeOptions(
       ClientContext& context, optional_ptr<TableFunctionInfo> info) override;
 
-  static unique_ptr<MultiFileReaderInterface> InitializeInterface(
-      ClientContext& context, MultiFileReader& reader, MultiFileList& file_list);
+  static unique_ptr<MultiFileReaderInterface> CreateInterface(ClientContext& context);
 
   bool ParseCopyOption(ClientContext& context, const string& key,
                        const vector<Value>& values, BaseFileReaderOptions& options,

--- a/src/include/file_scanner/arrow_multi_file_info.hpp
+++ b/src/include/file_scanner/arrow_multi_file_info.hpp
@@ -24,7 +24,7 @@ class ArrowFileScan;
 struct ArrowFileLocalState : public LocalTableFunctionState {
  public:
   explicit ArrowFileLocalState(ExecutionContext& execution_context)
-      : execution_context(execution_context){};
+      : execution_context(execution_context) {};
   //! Factory Pointer
   shared_ptr<ArrowFileScan> file_scan;
 
@@ -43,7 +43,7 @@ struct ArrowFileGlobalState : public GlobalTableFunctionState {
   ArrowFileGlobalState(ClientContext& context_p, idx_t total_file_count,
                        const MultiFileBindData& bind_data,
                        MultiFileGlobalState& global_state)
-      : global_state(global_state), context(context_p){};
+      : global_state(global_state), context(context_p) {};
 
   ~ArrowFileGlobalState() override = default;
 

--- a/src/include/file_scanner/arrow_multi_file_info.hpp
+++ b/src/include/file_scanner/arrow_multi_file_info.hpp
@@ -24,7 +24,7 @@ class ArrowFileScan;
 struct ArrowFileLocalState : public LocalTableFunctionState {
  public:
   explicit ArrowFileLocalState(ExecutionContext& execution_context)
-      : execution_context(execution_context) {};
+      : execution_context(execution_context){};
   //! Factory Pointer
   shared_ptr<ArrowFileScan> file_scan;
 
@@ -43,7 +43,7 @@ struct ArrowFileGlobalState : public GlobalTableFunctionState {
   ArrowFileGlobalState(ClientContext& context_p, idx_t total_file_count,
                        const MultiFileBindData& bind_data,
                        MultiFileGlobalState& global_state)
-      : global_state(global_state), context(context_p) {};
+      : global_state(global_state), context(context_p){};
 
   ~ArrowFileGlobalState() override = default;
 

--- a/src/include/ipc/stream_factory.hpp
+++ b/src/include/ipc/stream_factory.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 namespace ext_nanoarrow {
 
 class ArrowStreamFactory {
-  ArrowStreamFactory(){};
+  ArrowStreamFactory() {};
 };
 //! This Factory is a type invented by DuckDB. Notably, the Produce()
 //! function pointer is passed to the constructor of the ArrowScanFunctionData

--- a/src/include/ipc/stream_factory.hpp
+++ b/src/include/ipc/stream_factory.hpp
@@ -18,7 +18,7 @@ namespace duckdb {
 namespace ext_nanoarrow {
 
 class ArrowStreamFactory {
-  ArrowStreamFactory() {};
+  ArrowStreamFactory(){};
 };
 //! This Factory is a type invented by DuckDB. Notably, the Produce()
 //! function pointer is passed to the constructor of the ArrowScanFunctionData

--- a/src/include/ipc/stream_reader/base_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/base_stream_reader.hpp
@@ -24,7 +24,7 @@ namespace ext_nanoarrow {
 
 //! Missing in nanoarrow_ipc.hpp
 struct UniqueSharedBuffer {
-  struct ArrowIpcSharedBuffer data {};
+  struct ArrowIpcSharedBuffer data{};
 
   ~UniqueSharedBuffer() {
     if (data.private_src.allocator.free != nullptr) {
@@ -43,7 +43,7 @@ class IPCStreamReader {
  public:
   virtual ~IPCStreamReader() = default;
   explicit IPCStreamReader(Allocator& allocator)
-      : decoder(NewDuckDBArrowDecoder()), allocator(allocator){};
+      : decoder(NewDuckDBArrowDecoder()), allocator(allocator) {};
   //! Gets the output schema, which is the file schema with projection pushdown being
   //! considered
   const ArrowSchema* GetOutputSchema();

--- a/src/include/ipc/stream_reader/base_stream_reader.hpp
+++ b/src/include/ipc/stream_reader/base_stream_reader.hpp
@@ -24,7 +24,7 @@ namespace ext_nanoarrow {
 
 //! Missing in nanoarrow_ipc.hpp
 struct UniqueSharedBuffer {
-  struct ArrowIpcSharedBuffer data{};
+  struct ArrowIpcSharedBuffer data {};
 
   ~UniqueSharedBuffer() {
     if (data.private_src.allocator.free != nullptr) {
@@ -43,7 +43,7 @@ class IPCStreamReader {
  public:
   virtual ~IPCStreamReader() = default;
   explicit IPCStreamReader(Allocator& allocator)
-      : decoder(NewDuckDBArrowDecoder()), allocator(allocator) {};
+      : decoder(NewDuckDBArrowDecoder()), allocator(allocator){};
   //! Gets the output schema, which is the file schema with projection pushdown being
   //! considered
   const ArrowSchema* GetOutputSchema();

--- a/src/include/nanoarrow_extension.hpp
+++ b/src/include/nanoarrow_extension.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 class NanoarrowExtension : public Extension {
  public:
-  void Load(ExtensionLoader &db) override;
+  void Load(ExtensionLoader& db) override;
   std::string Name() override;
   std::string Version() const override;
 };

--- a/src/include/nanoarrow_extension.hpp
+++ b/src/include/nanoarrow_extension.hpp
@@ -9,12 +9,13 @@
 #pragma once
 
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 
 class NanoarrowExtension : public Extension {
  public:
-  void Load(DuckDB& db) override;
+  void Load(ExtensionLoader &db) override;
   std::string Name() override;
   std::string Version() const override;
 };

--- a/src/include/table_function/read_arrow.hpp
+++ b/src/include/table_function/read_arrow.hpp
@@ -17,7 +17,7 @@ namespace ext_nanoarrow {
 
 TableFunction ReadArrowStreamFunction();
 
-void RegisterReadArrowStream(ExtensionLoader &loader);
+void RegisterReadArrowStream(ExtensionLoader& loader);
 
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/include/table_function/read_arrow.hpp
+++ b/src/include/table_function/read_arrow.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 
 namespace duckdb {
@@ -16,7 +17,7 @@ namespace ext_nanoarrow {
 
 TableFunction ReadArrowStreamFunction();
 
-void RegisterReadArrowStream(DatabaseInstance& db);
+void RegisterReadArrowStream(ExtensionLoader &loader);
 
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/include/table_function/scan_arrow_ipc.hpp
+++ b/src/include/table_function/scan_arrow_ipc.hpp
@@ -18,7 +18,7 @@ namespace ext_nanoarrow {
 
 //! Arrow IPC Buffer, basically a pointer to the buffer and its size
 struct ArrowIPCBuffer {
-  ArrowIPCBuffer(const uint64_t ptr, const uint64_t size) : ptr(ptr), size(size){};
+  ArrowIPCBuffer(const uint64_t ptr, const uint64_t size) : ptr(ptr), size(size) {};
   uint64_t ptr;
   uint64_t size;
 };

--- a/src/include/table_function/scan_arrow_ipc.hpp
+++ b/src/include/table_function/scan_arrow_ipc.hpp
@@ -18,7 +18,7 @@ namespace ext_nanoarrow {
 
 //! Arrow IPC Buffer, basically a pointer to the buffer and its size
 struct ArrowIPCBuffer {
-  ArrowIPCBuffer(const uint64_t ptr, const uint64_t size) : ptr(ptr), size(size) {};
+  ArrowIPCBuffer(const uint64_t ptr, const uint64_t size) : ptr(ptr), size(size){};
   uint64_t ptr;
   uint64_t size;
 };
@@ -27,7 +27,7 @@ struct ArrowIPCBuffer {
 //! of CDataInterface header pointers, it takes a bunch of pointers pointing to
 //! buffers containing data in Arrow IPC format
 struct ScanArrowIPC {
-  static void RegisterReadArrowStream(ExtensionLoader &loader);
+  static void RegisterReadArrowStream(ExtensionLoader& loader);
 };
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/include/table_function/scan_arrow_ipc.hpp
+++ b/src/include/table_function/scan_arrow_ipc.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/function/table/arrow.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 #include "duckdb.hpp"
 
@@ -26,7 +27,7 @@ struct ArrowIPCBuffer {
 //! of CDataInterface header pointers, it takes a bunch of pointers pointing to
 //! buffers containing data in Arrow IPC format
 struct ScanArrowIPC {
-  static void RegisterReadArrowStream(DatabaseInstance& db);
+  static void RegisterReadArrowStream(ExtensionLoader &loader);
 };
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/include/write_arrow_stream.hpp
+++ b/src/include/write_arrow_stream.hpp
@@ -13,7 +13,7 @@
 namespace duckdb {
 namespace ext_nanoarrow {
 
-void RegisterArrowStreamCopyFunction(ExtensionLoader &loader);
+void RegisterArrowStreamCopyFunction(ExtensionLoader& loader);
 
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/include/write_arrow_stream.hpp
+++ b/src/include/write_arrow_stream.hpp
@@ -8,11 +8,12 @@
 
 #pragma once
 #include "duckdb/function/copy_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 namespace ext_nanoarrow {
 
-void RegisterArrowStreamCopyFunction(DatabaseInstance& db);
+void RegisterArrowStreamCopyFunction(ExtensionLoader &loader);
 
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/include/writer/to_arrow_ipc.hpp
+++ b/src/include/writer/to_arrow_ipc.hpp
@@ -29,7 +29,7 @@ class ToArrowIPCFunction {
   static constexpr idx_t DEFAULT_CHUNK_SIZE = 120;
 
   static TableFunction GetFunction();
-  static void RegisterToIPCFunction(ExtensionLoader &loader);
+  static void RegisterToIPCFunction(ExtensionLoader& loader);
 
  private:
   static unique_ptr<LocalTableFunctionState> InitLocal(

--- a/src/include/writer/to_arrow_ipc.hpp
+++ b/src/include/writer/to_arrow_ipc.hpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 #include "nanoarrow/hpp/unique.hpp"
 
@@ -28,7 +29,7 @@ class ToArrowIPCFunction {
   static constexpr idx_t DEFAULT_CHUNK_SIZE = 120;
 
   static TableFunction GetFunction();
-  static void RegisterToIPCFunction(DatabaseInstance& db);
+  static void RegisterToIPCFunction(ExtensionLoader &loader);
 
  private:
   static unique_ptr<LocalTableFunctionState> InitLocal(

--- a/src/nanoarrow_extension.cpp
+++ b/src/nanoarrow_extension.cpp
@@ -1,5 +1,3 @@
-#define DUCKDB_EXTENSION_MAIN
-
 #include "nanoarrow_extension.hpp"
 
 #include <string>
@@ -16,49 +14,45 @@
 
 namespace duckdb {
 
-  namespace {
+namespace {
 
-    struct NanoarrowVersion {
-      static void Register(ExtensionLoader &loader) {
-        auto fn = ScalarFunction("nanoarrow_version", {}, LogicalType::VARCHAR, ExecuteFn);
-        loader.RegisterFunction(fn);
-      }
-
-      static void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
-        result.SetValue(0, StringVector::AddString(result, ArrowNanoarrowVersion()));
-        result.SetVectorType(VectorType::CONSTANT_VECTOR);
-      }
-    };
-
-    void LoadInternal(ExtensionLoader &loader) {
-      NanoarrowVersion::Register(loader);
-      ext_nanoarrow::RegisterReadArrowStream(loader);
-      ext_nanoarrow::RegisterArrowStreamCopyFunction(loader);
-
-      ext_nanoarrow::ScanArrowIPC::RegisterReadArrowStream(loader);
-      ext_nanoarrow::ToArrowIPCFunction::RegisterToIPCFunction(loader);
-    }
-
-  }  // namespace
-
-  void NanoarrowExtension::Load(ExtensionLoader &loader) { LoadInternal(loader); }
-
-  std::string NanoarrowExtension::Name() { return "nanoarrow"; }
-
-  std::string NanoarrowExtension::Version() const {
-#ifdef EXT_VERSION_NANOARROW
-    return EXT_VERSION_NANOARROW;
-#else
-    return "";
-#endif
+struct NanoarrowVersion {
+  static void Register(ExtensionLoader& loader) {
+    auto fn = ScalarFunction("nanoarrow_version", {}, LogicalType::VARCHAR, ExecuteFn);
+    loader.RegisterFunction(fn);
   }
+
+  static void ExecuteFn(DataChunk& args, ExpressionState& state, Vector& result) {
+    result.SetValue(0, StringVector::AddString(result, ArrowNanoarrowVersion()));
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
+};
+
+void LoadInternal(ExtensionLoader& loader) {
+  NanoarrowVersion::Register(loader);
+  ext_nanoarrow::RegisterReadArrowStream(loader);
+  ext_nanoarrow::RegisterArrowStreamCopyFunction(loader);
+
+  ext_nanoarrow::ScanArrowIPC::RegisterReadArrowStream(loader);
+  ext_nanoarrow::ToArrowIPCFunction::RegisterToIPCFunction(loader);
+}
+
+}  // namespace
+
+void NanoarrowExtension::Load(ExtensionLoader& loader) { LoadInternal(loader); }
+
+std::string NanoarrowExtension::Name() { return "nanoarrow"; }
+
+std::string NanoarrowExtension::Version() const {
+#ifdef EXT_VERSION_NANOARROW
+  return EXT_VERSION_NANOARROW;
+#else
+  return "";
+#endif
+}
 
 }  // namespace duckdb
 
-DUCKDB_CPP_EXTENSION_ENTRY(nanoarrow, loader) {
-  duckdb::LoadInternal(loader);
+extern "C" {
+DUCKDB_CPP_EXTENSION_ENTRY(nanoarrow, loader) { duckdb::LoadInternal(loader); }
 }
-
-#ifndef DUCKDB_EXTENSION_MAIN
-#error DUCKDB_EXTENSION_MAIN not defined
-#endif

--- a/src/scanner/read_arrow.cpp
+++ b/src/scanner/read_arrow.cpp
@@ -75,7 +75,7 @@ struct ReadArrowStream : ArrowTableFunction {
 
 TableFunction ReadArrowStreamFunction() { return ReadArrowStream::Function(); }
 
-void RegisterReadArrowStream(ExtensionLoader &loader) {
+void RegisterReadArrowStream(ExtensionLoader& loader) {
   auto function = ReadArrowStream::Function();
   loader.RegisterFunction(function);
   // So we can accept a list of paths as well e.g., ['file_1.arrow','file_2.arrow']

--- a/src/scanner/read_arrow.cpp
+++ b/src/scanner/read_arrow.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/main/extension_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
@@ -75,13 +75,13 @@ struct ReadArrowStream : ArrowTableFunction {
 
 TableFunction ReadArrowStreamFunction() { return ReadArrowStream::Function(); }
 
-void RegisterReadArrowStream(DatabaseInstance& db) {
+void RegisterReadArrowStream(ExtensionLoader &loader) {
   auto function = ReadArrowStream::Function();
-  ExtensionUtil::RegisterFunction(db, function);
+  loader.RegisterFunction(function);
   // So we can accept a list of paths as well e.g., ['file_1.arrow','file_2.arrow']
   function.arguments = {LogicalType::LIST(LogicalType::VARCHAR)};
-  ExtensionUtil::RegisterFunction(db, function);
-  auto& config = DBConfig::GetConfig(db);
+  loader.RegisterFunction(function);
+  auto& config = DBConfig::GetConfig(loader.GetDatabaseInstance());
   config.replacement_scans.emplace_back(ReadArrowStream::ScanReplacement);
 }
 

--- a/src/scanner/scan_arrow_ipc.cpp
+++ b/src/scanner/scan_arrow_ipc.cpp
@@ -8,9 +8,9 @@
 #include "ipc/stream_reader/base_stream_reader.hpp"
 
 #include "duckdb/function/function.hpp"
+#include "duckdb/function/table/arrow.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 #include "duckdb/function/table_function.hpp"
-#include "duckdb/function/table/arrow.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 

--- a/src/scanner/scan_arrow_ipc.cpp
+++ b/src/scanner/scan_arrow_ipc.cpp
@@ -66,7 +66,7 @@ struct ScanArrowIPCFunction : ArrowTableFunction {
   }
 };
 
-void ScanArrowIPC::RegisterReadArrowStream(ExtensionLoader &loader) {
+void ScanArrowIPC::RegisterReadArrowStream(ExtensionLoader& loader) {
   auto function = ScanArrowIPCFunction::Function();
   loader.RegisterFunction(function);
 }

--- a/src/scanner/scan_arrow_ipc.cpp
+++ b/src/scanner/scan_arrow_ipc.cpp
@@ -1,6 +1,5 @@
 
 #include "table_function/scan_arrow_ipc.hpp"
-#include "duckdb/main/extension_util.hpp"
 #include "ipc/stream_factory.hpp"
 #include "table_function/arrow_ipc_function_data.hpp"
 
@@ -11,7 +10,10 @@
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/function/table/arrow.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
 namespace duckdb {
 
 namespace ext_nanoarrow {
@@ -35,9 +37,9 @@ struct ScanArrowIPCFunction : ArrowTableFunction {
     res->factory->GetFileSchema(res->schema_root);
 
     DBConfig& config = DatabaseInstance::GetDatabase(context).config;
-    PopulateArrowTableType(config, res->arrow_table, res->schema_root, names,
-                           return_types);
-    QueryResult::DeduplicateColumns(names);
+    PopulateArrowTableSchema(config, res->arrow_table, res->schema_root.arrow_schema);
+    names = res->arrow_table.GetNames();
+    return_types = res->arrow_table.GetTypes();
     res->all_types = return_types;
     if (return_types.empty()) {
       throw InvalidInputException(
@@ -64,9 +66,9 @@ struct ScanArrowIPCFunction : ArrowTableFunction {
   }
 };
 
-void ScanArrowIPC::RegisterReadArrowStream(DatabaseInstance& db) {
+void ScanArrowIPC::RegisterReadArrowStream(ExtensionLoader &loader) {
   auto function = ScanArrowIPCFunction::Function();
-  ExtensionUtil::RegisterFunction(db, function);
+  loader.RegisterFunction(function);
 }
 
 }  // namespace ext_nanoarrow

--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -1,14 +1,12 @@
 #include "writer/to_arrow_ipc.hpp"
 
-#include "duckdb/main/extension_util.hpp"
-
 #include "writer/column_data_collection_serializer.hpp"
 
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
-
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 
@@ -189,9 +187,9 @@ TableFunction ToArrowIPCFunction::GetFunction() {
   return fun;
 }
 
-void ToArrowIPCFunction::RegisterToIPCFunction(DatabaseInstance& db) {
+void ToArrowIPCFunction::RegisterToIPCFunction(ExtensionLoader &loader) {
   const auto function = GetFunction();
-  ExtensionUtil::RegisterFunction(db, function);
+  loader.RegisterFunction(function);
 }
 }  // namespace ext_nanoarrow
 }  // namespace duckdb

--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -187,7 +187,7 @@ TableFunction ToArrowIPCFunction::GetFunction() {
   return fun;
 }
 
-void ToArrowIPCFunction::RegisterToIPCFunction(ExtensionLoader &loader) {
+void ToArrowIPCFunction::RegisterToIPCFunction(ExtensionLoader& loader) {
   const auto function = GetFunction();
   loader.RegisterFunction(function);
 }

--- a/src/writer/write_arrow_stream.cpp
+++ b/src/writer/write_arrow_stream.cpp
@@ -247,7 +247,7 @@ void ArrowWriteFlushBatch(ClientContext& context, FunctionData& bind_data,
 
 }  // namespace
 
-void RegisterArrowStreamCopyFunction(ExtensionLoader &loader) {
+void RegisterArrowStreamCopyFunction(ExtensionLoader& loader) {
   CopyFunction function("arrows");
   function.copy_to_bind = ArrowWriteBind;
   function.copy_to_initialize_global = ArrowWriteInitializeGlobal;

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -7,21 +7,22 @@ from duckdb import DuckDBPyConnection
 dir = os.path.dirname(os.path.abspath(__file__))
 build_type = "release"
 
+
 @pytest.fixture(scope="function")
 def duckdb_empty_cursor(request):
     connection = duckdb.connect('')
     cursor = connection.cursor()
     return cursor
 
+
 def add_extension(extension_name, conn: Union[str, DuckDBPyConnection] = '') -> DuckDBPyConnection:
-    if (isinstance(conn, str)):
-        config = {
-            'allow_unsigned_extensions' : 'true'
-        }
+    if isinstance(conn, str):
+        config = {'allow_unsigned_extensions': 'true'}
         conn = duckdb.connect(conn or '', config=config)
     file_path = f"'{dir}/../../build/{build_type}/extension/{extension_name}/{extension_name}.duckdb_extension'"
     conn.execute(f"LOAD {file_path}")
     return conn
+
 
 @pytest.fixture(scope="function")
 def require():
@@ -32,6 +33,7 @@ def require():
 
     return _require
 
+
 @pytest.fixture(scope='function')
 def connection():
-	return add_extension('nanoarrow')
+    return add_extension('nanoarrow')

--- a/test/python/test_arrow_ipc_scan.py
+++ b/test/python/test_arrow_ipc_scan.py
@@ -5,55 +5,76 @@ import pyarrow.ipc as ipc
 
 
 def get_record_batch():
-   data = [
-          pa.array([1, 2, 3, 4]),
-          pa.array(['foo', 'bar', 'baz', None]),
-          pa.array([True, None, False, True])
-      ]
+    data = [pa.array([1, 2, 3, 4]), pa.array(['foo', 'bar', 'baz', None]), pa.array([True, None, False, True])]
 
-   return pa.record_batch(data, names=['f0', 'f1', 'f2'])
+    return pa.record_batch(data, names=['f0', 'f1', 'f2'])
+
 
 def tables_match(result):
-   assert result == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True), (1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+    assert result == [
+        (1, 'foo', True),
+        (2, 'bar', None),
+        (3, 'baz', False),
+        (4, None, True),
+        (1, 'foo', True),
+        (2, 'bar', None),
+        (3, 'baz', False),
+        (4, None, True),
+        (1, 'foo', True),
+        (2, 'bar', None),
+        (3, 'baz', False),
+        (4, None, True),
+        (1, 'foo', True),
+        (2, 'bar', None),
+        (3, 'baz', False),
+        (4, None, True),
+        (1, 'foo', True),
+        (2, 'bar', None),
+        (3, 'baz', False),
+        (4, None, True),
+    ]
+
 
 class TestArrowIPCBufferRead(object):
-   def test_single_buffer(self, connection):
-      batch = get_record_batch()
-      sink = pa.BufferOutputStream()
-      with pa.ipc.new_stream(sink, batch.schema) as writer:
-         for i in range(5):
+    def test_single_buffer(self, connection):
+        batch = get_record_batch()
+        sink = pa.BufferOutputStream()
+        with pa.ipc.new_stream(sink, batch.schema) as writer:
+            for i in range(5):
+                writer.write_batch(batch)
+        buffer = sink.getvalue()
+        with pa.BufferReader(buffer) as buf_reader:
+            msg_reader = ipc.MessageReader.open_stream(buf_reader)
+            tables_match(connection.from_arrow(msg_reader).fetchall())
+
+    def test_multi_buffers(self, connection):
+        batch = get_record_batch()
+        sink = pa.BufferOutputStream()
+
+        with pa.ipc.new_stream(sink, batch.schema) as writer:
+            for _ in range(5):  # Write 5 batches into one stream
+                writer.write_batch(batch)
+
+        buffer = sink.getvalue()
+
+        with pa.BufferReader(buffer) as buf_reader:
+            msg_reader = ipc.MessageReader.open_stream(buf_reader)
+            tables_match(connection.from_arrow(msg_reader).fetchall())
+
+    def test_replacement_scan(self, connection):
+
+        batch = get_record_batch()
+        sink = pa.BufferOutputStream()
+
+        with pa.ipc.new_stream(sink, batch.schema) as writer:
             writer.write_batch(batch)
-      buffer = sink.getvalue()
-      with pa.BufferReader(buffer) as buf_reader:
-         msg_reader = ipc.MessageReader.open_stream(buf_reader)
-         tables_match(connection.from_arrow(msg_reader).fetchall())
 
-   def test_multi_buffers(self, connection):
-      batch = get_record_batch()
-      sink = pa.BufferOutputStream()
+        buffer = sink.getvalue()
 
-      with pa.ipc.new_stream(sink, batch.schema) as writer:
-          for _ in range(5):  # Write 5 batches into one stream
-              writer.write_batch(batch)
-
-      buffer = sink.getvalue()
-
-      with pa.BufferReader(buffer) as buf_reader:
-         msg_reader = ipc.MessageReader.open_stream(buf_reader)
-         tables_match(connection.from_arrow(msg_reader).fetchall())
-
-   def test_replacement_scan(self, connection):
-
-      batch = get_record_batch()
-      sink = pa.BufferOutputStream()
-
-      with pa.ipc.new_stream(sink, batch.schema) as writer:
-         writer.write_batch(batch)
-
-      buffer = sink.getvalue()
-
-      with pa.BufferReader(buffer) as buf_reader:
-         msg_reader = ipc.MessageReader.open_stream(buf_reader)
-         with pytest.raises(duckdb.InvalidInputException,
-                 match="not suitable for replacement scans",):
-            connection.execute("FROM msg_reader")
+        with pa.BufferReader(buffer) as buf_reader:
+            msg_reader = ipc.MessageReader.open_stream(buf_reader)
+            with pytest.raises(
+                duckdb.InvalidInputException,
+                match="not suitable for replacement scans",
+            ):
+                connection.execute("FROM msg_reader")

--- a/test/python/test_arrow_ipc_writer.py
+++ b/test/python/test_arrow_ipc_writer.py
@@ -3,35 +3,38 @@ import pyarrow as pa
 import duckdb
 import pyarrow.ipc as ipc
 
+
 def create_table(connection):
-	connection.execute("CREATE TABLE T (f0 integer, f1 varchar, f2 bool )")
-	connection.execute("INSERT INTO T values (1, 'foo', true),(2, 'bar', NULL), (3, 'baz', false), (4, NULL, true) ")
+    connection.execute("CREATE TABLE T (f0 integer, f1 varchar, f2 bool )")
+    connection.execute("INSERT INTO T values (1, 'foo', true),(2, 'bar', NULL), (3, 'baz', false), (4, NULL, true) ")
+
 
 def tables_match(result):
-	print(result)
-	assert result == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+    print(result)
+    assert result == [(1, 'foo', True), (2, 'bar', None), (3, 'baz', False), (4, None, True)]
+
 
 class TestArrowIPCBufferWriter(object):
-	def test_round_trip(self, connection):
-		create_table(connection)
-		buffers = connection.execute("FROM to_arrow_ipc((FROM T))").fetchall()
-		buffer = pa.py_buffer(buffers[0][0] + buffers[1][0])
-		with pa.BufferReader(buffer) as buf_reader:
-			msg_reader = ipc.MessageReader.open_stream(buf_reader)
-			tables_match(connection.from_arrow(msg_reader).fetchall())
+    def test_round_trip(self, connection):
+        create_table(connection)
+        buffers = connection.execute("FROM to_arrow_ipc((FROM T))").fetchall()
+        buffer = pa.py_buffer(buffers[0][0] + buffers[1][0])
+        with pa.BufferReader(buffer) as buf_reader:
+            msg_reader = ipc.MessageReader.open_stream(buf_reader)
+            tables_match(connection.from_arrow(msg_reader).fetchall())
 
-	def test_arrow_read_duck_buffers(self, connection):
-		create_table(connection)
-		buffers = connection.execute("FROM to_arrow_ipc((FROM T))").fetchall()
-		arrow_buffers = []
-		# We have to concatenate the schema to the data
-		arrow_buffers.append(pa.py_buffer(buffers[0][0] + buffers[1][0]))
-		assert buffers[0][1] == True
-		assert buffers[1][1] == False
-		batches = []
-		with pa.BufferReader(arrow_buffers[0]) as reader:
-			stream_reader = ipc.RecordBatchStreamReader(reader)
-			schema = stream_reader.schema
-			batches.extend(stream_reader)
-		arrow_table = pa.Table.from_batches(batches, schema=schema)
-		tables_match(connection.execute("FROM arrow_table").fetchall())
+    def test_arrow_read_duck_buffers(self, connection):
+        create_table(connection)
+        buffers = connection.execute("FROM to_arrow_ipc((FROM T))").fetchall()
+        arrow_buffers = []
+        # We have to concatenate the schema to the data
+        arrow_buffers.append(pa.py_buffer(buffers[0][0] + buffers[1][0]))
+        assert buffers[0][1] == True
+        assert buffers[1][1] == False
+        batches = []
+        with pa.BufferReader(arrow_buffers[0]) as reader:
+            stream_reader = ipc.RecordBatchStreamReader(reader)
+            schema = stream_reader.schema
+            batches.extend(stream_reader)
+        arrow_table = pa.Table.from_batches(batches, schema=schema)
+        tables_match(connection.execute("FROM arrow_table").fetchall())

--- a/test/python/test_integration.py
+++ b/test/python/test_integration.py
@@ -16,33 +16,53 @@ import tempfile
 # Not implemented Error: Unsupported Internal Arrow Type: "d" Union
 # "generated_union.stream"
 
-little_big_integration_files = ["generated_null_trivial.stream", "generated_primitive_large_offsets.stream","generated_custom_metadata.stream","generated_datetime.stream","generated_decimal.stream","generated_map_non_canonical.stream","generated_map.stream","generated_nested_large_offsets.stream","generated_nested.stream","generated_null.stream","generated_primitive_no_batches.stream","generated_primitive_zerolength.stream","generated_primitive.stream","generated_recursive_nested.stream"]
+little_big_integration_files = [
+    "generated_null_trivial.stream",
+    "generated_primitive_large_offsets.stream",
+    "generated_custom_metadata.stream",
+    "generated_datetime.stream",
+    "generated_decimal.stream",
+    "generated_map_non_canonical.stream",
+    "generated_map.stream",
+    "generated_nested_large_offsets.stream",
+    "generated_nested.stream",
+    "generated_null.stream",
+    "generated_primitive_no_batches.stream",
+    "generated_primitive_zerolength.stream",
+    "generated_primitive.stream",
+    "generated_recursive_nested.stream",
+]
 
 compression_2_0_0 = ["generated_uncompressible_zstd.stream", "generated_zstd.stream"]
 
 script_path = os.path.dirname(os.path.abspath(__file__))
 
-test_folder = os.path.join(script_path,'..','..','arrow-testing','data','arrow-ipc-stream','integration')
+test_folder = os.path.join(script_path, '..', '..', 'arrow-testing', 'data', 'arrow-ipc-stream', 'integration')
 
 # All Test Folders:
-big_endian_folder = os.path.join(test_folder,'1.0.0-bigendian')
-little_endian_folder = os.path.join(test_folder,'1.0.0-littleendian')
-compression_folder = os.path.join(test_folder,'2.0.0-compression')
+big_endian_folder = os.path.join(test_folder, '1.0.0-bigendian')
+little_endian_folder = os.path.join(test_folder, '1.0.0-littleendian')
+compression_folder = os.path.join(test_folder, '2.0.0-compression')
 
-def compare_result(arrow_result,duckdb_result, con):
-    return con.execute("""
+
+def compare_result(arrow_result, duckdb_result, con):
+    return con.execute(
+        """
     SELECT COUNT(*) = 0
     FROM (
         (SELECT * FROM arrow_result EXCEPT SELECT * FROM duckdb_result)
         UNION
         (SELECT * FROM duckdb_result EXCEPT SELECT * FROM arrow_result)
-    ) """).fetchone()[0]
+    ) """
+    ).fetchone()[0]
+
 
 # 1. Compare result from reading the IPC file in Arrow, and in Duckdb
 def compare_ipc_file_reader(con, file):
     arrow_result = ipc.open_stream(file).read_all()
     duckdb_file_result = con.sql(f"FROM read_arrow('{file}')").arrow()
     assert compare_result(arrow_result, duckdb_file_result, con)
+
 
 # 2. Now test the writer, write it to a file from DuckDB, read it with arrow and compare
 def compare_ipc_file_writer(con, file):
@@ -53,12 +73,14 @@ def compare_ipc_file_writer(con, file):
         duckdb_file_result = con.sql(f"FROM read_arrow('{file}')").arrow()
         assert compare_result(arrow_result, duckdb_file_result, con)
 
+
 # 3. Compare result from reading the IPC file in Arrow, and in Duckdb
 def compare_ipc_buffer_reader(con, file):
     arrow_result = ipc.open_stream(file).read_all()
     reader = mr.open_stream(file)
     duckdb_struct_result = con.from_arrow(reader).arrow()
     assert compare_result(arrow_result, duckdb_struct_result, con)
+
 
 # 4. Now test the DuckDB buffer writer, by reading it back with arrow and comparing
 def compare_ipc_buffer_writer(con, file):
@@ -67,7 +89,7 @@ def compare_ipc_buffer_writer(con, file):
     if not buffers:
         return
     arrow_buffers = []
-    for i in range (1, len(buffers)):
+    for i in range(1, len(buffers)):
         # We have to concatenate the schema to the data
         arrow_buffers.append(pa.py_buffer(buffers[0][0] + buffers[i][0]))
 
@@ -85,28 +107,28 @@ def compare_ipc_buffer_writer(con, file):
 class TestArrowIntegrationTests(object):
     def test_read_ipc_file(self, connection):
         for file in little_big_integration_files:
-            compare_ipc_file_reader(connection,os.path.join(big_endian_folder,file))
-            compare_ipc_file_reader(connection,os.path.join(little_endian_folder,file))
+            compare_ipc_file_reader(connection, os.path.join(big_endian_folder, file))
+            compare_ipc_file_reader(connection, os.path.join(little_endian_folder, file))
         for file in compression_2_0_0:
-            compare_ipc_file_reader(connection,os.path.join(compression_folder,file))
+            compare_ipc_file_reader(connection, os.path.join(compression_folder, file))
 
     def test_write_ipc_file(self, connection):
         for file in little_big_integration_files:
-            compare_ipc_file_writer(connection,os.path.join(big_endian_folder,file))
-            compare_ipc_file_writer(connection,os.path.join(little_endian_folder,file))
+            compare_ipc_file_writer(connection, os.path.join(big_endian_folder, file))
+            compare_ipc_file_writer(connection, os.path.join(little_endian_folder, file))
         for file in compression_2_0_0:
-            compare_ipc_file_reader(connection,os.path.join(compression_folder,file))
+            compare_ipc_file_reader(connection, os.path.join(compression_folder, file))
 
     def test_read_ipc_buffer(self, connection):
         for file in little_big_integration_files:
-            compare_ipc_buffer_reader(connection,os.path.join(big_endian_folder,file))
-            compare_ipc_buffer_reader(connection,os.path.join(little_endian_folder,file))
+            compare_ipc_buffer_reader(connection, os.path.join(big_endian_folder, file))
+            compare_ipc_buffer_reader(connection, os.path.join(little_endian_folder, file))
         for file in compression_2_0_0:
-            compare_ipc_file_reader(connection,os.path.join(compression_folder,file))
+            compare_ipc_file_reader(connection, os.path.join(compression_folder, file))
 
     def test_write_ipc_buffer(self, connection):
         for file in little_big_integration_files:
-            compare_ipc_buffer_writer(connection,os.path.join(big_endian_folder,file))
-            compare_ipc_buffer_writer(connection,os.path.join(little_endian_folder,file))
+            compare_ipc_buffer_writer(connection, os.path.join(big_endian_folder, file))
+            compare_ipc_buffer_writer(connection, os.path.join(little_endian_folder, file))
         for file in compression_2_0_0:
-            compare_ipc_buffer_writer(connection,os.path.join(compression_folder,file))
+            compare_ipc_buffer_writer(connection, os.path.join(compression_folder, file))

--- a/test/sql/arrow_testing.test
+++ b/test/sql/arrow_testing.test
@@ -1,6 +1,6 @@
-# name:
+# name: test/sql/arrow_testing.test
 # description: test nanoarrow extension
-# group: [nanoarrow]
+# group: [sql]
 
 # Require statement will ensure this test is run with this extension loaded
 require nanoarrow

--- a/test/sql/multifile_reading.test
+++ b/test/sql/multifile_reading.test
@@ -1,6 +1,6 @@
 # name: test/sql/multifile_reading.test
 # description: Test read_arrow over multiple files.
-# group: [nanoarrow]
+# group: [sql]
 
 require nanoarrow
 

--- a/test/sql/nanoarrow.test
+++ b/test/sql/nanoarrow.test
@@ -1,6 +1,6 @@
 # name: test/sql/nanoarrow.test
 # description: test nanoarrow extension
-# group: [nanoarrow]
+# group: [sql]
 
 # Before we load the extension, this will fail
 statement error

--- a/test/sql/read_arrow.test
+++ b/test/sql/read_arrow.test
@@ -1,6 +1,6 @@
 # name: test/sql/read_arrow.test
 # description: test nanoarrow extension
-# group: [nanoarrow]
+# group: [sql]
 
 # Require statement will ensure this test is run with this extension loaded
 require nanoarrow

--- a/test/sql/read_arrow_file.test
+++ b/test/sql/read_arrow_file.test
@@ -1,6 +1,6 @@
 # name: test/sql/read_arrow_file.test
 # description: test nanoarrow extension when reading arrow file (with footer)
-# group: [nanoarrow]
+# group: [sql]
 
 # The files here should be generated with "with pa.ipc.new_file(file_path, table.schema) as writer:"
 # Require statement will ensure this test is run with this extension loaded

--- a/test/sql/test_copy_to.test
+++ b/test/sql/test_copy_to.test
@@ -1,6 +1,6 @@
 # name: test/sql/test_copy_to.test
 # description: test copy to functionality and options
-# group: [nanoarrow]
+# group: [sql]
 
 # Require statement will ensure this test is run with this extension loaded
 require nanoarrow

--- a/test/sql/to_arrow_ipc.test
+++ b/test/sql/to_arrow_ipc.test
@@ -1,6 +1,6 @@
 # name: test/sql/to_arrow_ipc.test
 # description: round trip arrow serialization
-# group: [nanoarrow]
+# group: [sql]
 
 # NOTE: for now there's not much we can test here, since we cannot really pass pointers from the
 #       serialized blobs to the scan_arrow_ipc function in SQL. Therefore tests of these features

--- a/test/sql/write_arrow_stream.test
+++ b/test/sql/write_arrow_stream.test
@@ -1,6 +1,6 @@
 # name: test/sql/write_arrow_stream.test
 # description: test nanoarrow extension
-# group: [nanoarrow]
+# group: [sql]
 
 # Require statement will ensure this test is run with this extension loaded
 require nanoarrow


### PR DESCRIPTION
* Followed [extension update manual](https://github.com/duckdb/community-extensions/blob/main/UPDATING.md)
* duckdb submodule bumped to HEAD of v1.4-andium
* extension-ci-tools bumped to HEAD of main
* Moved to [ExtensionLoader](https://github.com/duckdb/duckdb/pull/17772/)
* Moved to [generic settings](https://github.com/duckdb/duckdb/pull/18447)
* Moved to [new Arrow API](https://github.com/duckdb/duckdb/pull/18246)
* ~format-fix~ pre-commit

Builds and tests work locally

**Update**: also updated the python workflow since the python package is now in its own repo at [duckdb/duckdb-python](https://github.com/duckdb/duckdb-python). It always runs against main of both duckdb and duckdb-python, which isn't great. That's not a change, that's how it worked before as well. It'd be better to test the extension against either a stable version / tag of both duckdb and duckdb-python or some well-known ref (e.g. v*.*-* or main). Haven't really thought this out any further. It might be good to give this some thought outside of the context of this pr.