### PR TITLE
Fix casting on return to prevent compile error on linux/arm64/clang

### DIFF
--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -39,7 +39,7 @@ unique_ptr<LocalTableFunctionState> ToArrowIPCFunction::InitLocal(
   auto properties = context.client.GetClientProperties();
   local_state->serializer = make_uniq<ColumnDataCollectionSerializer>(
       properties, BufferAllocator::Get(context.client));
-  return local_state;
+  return std::move(local_state);
 }
 
 unique_ptr<GlobalTableFunctionState> ToArrowIPCFunction::InitGlobal(


### PR DESCRIPTION
This is a fix for https://github.com/paleolimbot/duckdb-nanoarrow/issues/41