### PR TITLE
Add Arrow IPC end-of-stream marker to to_arrow_ipc() output

### DIFF
--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -168,15 +168,22 @@ OperatorFinalizeResultType ToArrowIPCFunction::FunctionFinal(ExecutionContext& c
   auto& local_state = data_p.local_state->Cast<ToArrowIpcLocalState>();
 
   if (local_state.appender) {
-    // If we have an appender, we serialize the array into a message and insert it to the
-    // chunk
+    // Flush remaining buffered data first, then come back to emit EOS
     nanoarrow::UniqueBuffer arrow_serialized_ipc_buffer;
     SerializeArray(local_state, arrow_serialized_ipc_buffer);
     InsertMessageToChunk(arrow_serialized_ipc_buffer, output);
-
-    // This is always a data message, so we set the second column to false.
     output.data[1].SetValue(0, Value::BOOLEAN(false));
+    local_state.appender.reset();
+    return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
   }
+
+  // Emit the Arrow IPC end-of-stream marker (continuation token + 0-length metadata)
+  uint8_t end_of_stream[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00};
+  nanoarrow::UniqueBuffer eos_buffer;
+  ArrowBufferInit(eos_buffer.get());
+  ArrowBufferAppend(eos_buffer.get(), end_of_stream, sizeof(end_of_stream));
+  InsertMessageToChunk(eos_buffer, output);
+  output.data[1].SetValue(0, Value::BOOLEAN(false));
 
   return OperatorFinalizeResultType::FINISHED;
 }

--- a/test/python/test_integration.py
+++ b/test/python/test_integration.py
@@ -88,10 +88,13 @@ def compare_ipc_buffer_writer(con, file):
     buffers = con.execute(f"FROM to_arrow_ipc((FROM read_arrow('{file}')))").fetchall()
     if not buffers:
         return
+    # Skip schema (first row) and EOS marker (last row), keep only data batches
     arrow_buffers = []
-    for i in range(1, len(buffers)):
-        # We have to concatenate the schema to the data
+    for i in range(1, len(buffers) - 1):
         arrow_buffers.append(pa.py_buffer(buffers[0][0] + buffers[i][0]))
+
+    if not arrow_buffers:
+        return
 
     batches = []
     for buffer in arrow_buffers:
@@ -101,6 +104,21 @@ def compare_ipc_buffer_writer(con, file):
             batches.extend(stream_reader)
 
     duckdb_struct_result = pa.Table.from_batches(batches, schema=schema)
+    assert compare_result(arrow_result, duckdb_struct_result, con)
+
+
+# 5. Test that concatenating all to_arrow_ipc() blobs produces a valid IPC stream
+#    (i.e., includes the end-of-stream marker)
+def compare_ipc_buffer_writer_full_stream(con, file):
+    arrow_result = ipc.open_stream(file).read_all()
+    buffers = con.execute(f"FROM to_arrow_ipc((FROM read_arrow('{file}')))").fetchall()
+    # Need at least schema + EOS (2 rows) with data in between
+    if len(buffers) < 3:
+        return
+    # Concatenate all blobs into one complete IPC stream
+    full_stream = b"".join(row[0] for row in buffers)
+    reader = ipc.RecordBatchStreamReader(pa.BufferReader(full_stream))
+    duckdb_struct_result = reader.read_all()
     assert compare_result(arrow_result, duckdb_struct_result, con)
 
 
@@ -132,3 +150,10 @@ class TestArrowIntegrationTests(object):
             compare_ipc_buffer_writer(connection, os.path.join(little_endian_folder, file))
         for file in compression_2_0_0:
             compare_ipc_buffer_writer(connection, os.path.join(compression_folder, file))
+
+    def test_write_ipc_buffer_full_stream(self, connection):
+        for file in little_big_integration_files:
+            compare_ipc_buffer_writer_full_stream(connection, os.path.join(big_endian_folder, file))
+            compare_ipc_buffer_writer_full_stream(connection, os.path.join(little_endian_folder, file))
+        for file in compression_2_0_0:
+            compare_ipc_buffer_writer_full_stream(connection, os.path.join(compression_folder, file))


### PR DESCRIPTION
## Summary

- `to_arrow_ipc()` was not emitting the 8-byte EOS sentinel (`0xFFFFFFFF 0x00000000`) required by the [Arrow IPC streaming format spec](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format)
- This caused consumers like DuckDB-WASM's `insertArrowFromIPCStream` to fail with `"Header-type of flatbuffer-encoded Message is not RecordBatch"` when reading the concatenated stream
- The fix emits the EOS marker as a final blob row in `FunctionFinal()`, consistent with how `ArrowStreamWriter::Finalize()` already handles it for file-based output

## Changes

- **`src/writer/to_arrow_ipc.cpp`**: When `FunctionFinal()` has buffered data, it now flushes it and returns `HAVE_MORE_OUTPUT`, then emits the EOS marker on the next call. If there's no buffered data, it emits the EOS directly.
- **`test/python/test_integration.py`**: Added `compare_ipc_buffer_writer_full_stream()` which concatenates all output blobs into a single buffer and reads it as one `RecordBatchStreamReader` — this validates the stream is properly terminated.

## Context

Reported in https://github.com/apache/arrow-nanoarrow/issues/867, originally discussed in duckdb/duckdb-node-neo#45.

## Test plan

- [ ] Existing `test_write_ipc_buffer` tests still pass (per-batch reading)
- [ ] New `test_write_ipc_buffer_full_stream` tests pass (full concatenated stream reading)