### PR TITLE
Fix memory leak in to_arrow_ipc()

### DIFF
--- a/src/writer/column_data_collection_serializer.cpp
+++ b/src/writer/column_data_collection_serializer.cpp
@@ -42,6 +42,12 @@ ColumnDataCollectionSerializer::ColumnDataCollectionSerializer(ClientProperties 
 
 void ColumnDataCollectionSerializer::Init(const ArrowSchema* schema_p,
                                           const vector<LogicalType>& logical_types) {
+  header.reset();
+  body.reset();
+  encoder.reset();
+  chunk_view.reset();
+  chunk_arrow.reset();
+
   InitArrowDuckBuffer(header.get(), allocator);
   InitArrowDuckBuffer(body.get(), allocator);
   NANOARROW_THROW_NOT_OK(ArrowIpcEncoderInit(encoder.get()));

--- a/src/writer/to_arrow_ipc.cpp
+++ b/src/writer/to_arrow_ipc.cpp
@@ -15,7 +15,7 @@ namespace ext_nanoarrow {
 
 struct ToArrowIpcFunctionData : public TableFunctionData {
   ToArrowIpcFunctionData() = default;
-  ArrowSchema schema{};
+  nanoarrow::UniqueSchema schema;
   vector<LogicalType> logical_types;
   const idx_t chunk_size = ToArrowIPCFunction::DEFAULT_CHUNK_SIZE * STANDARD_VECTOR_SIZE;
 };
@@ -40,6 +40,10 @@ unique_ptr<LocalTableFunctionState> ToArrowIPCFunction::InitLocal(
   auto properties = context.client.GetClientProperties();
   local_state->serializer = make_uniq<ColumnDataCollectionSerializer>(
       properties, BufferAllocator::Get(context.client));
+  // Init() allocates an encoder and an array view, so it belongs here and not
+  // in Function(), which runs for every incoming chunk.
+  auto& data = input.bind_data->Cast<ToArrowIpcFunctionData>();
+  local_state->serializer->Init(data.schema.get(), data.logical_types);
   return std::move(local_state);
 }
 
@@ -63,15 +67,16 @@ unique_ptr<FunctionData> ToArrowIPCFunction::Bind(ClientContext& context,
   // Create the Arrow schema
   auto properties = context.GetClientProperties();
   result->logical_types = input.input_table_types;
-  ArrowConverter::ToArrowSchema(&result->schema, input.input_table_types,
+  ArrowConverter::ToArrowSchema(result->schema.get(), input.input_table_types,
                                 input.input_table_names, properties);
   return std::move(result);
 }
 
 void SerializeArray(const ToArrowIpcLocalState& local_state,
                     nanoarrow::UniqueBuffer& arrow_serialized_ipc_buffer) {
-  ArrowArray arr = local_state.appender->Finalize();
-  local_state.serializer->Serialize(arr);
+  ArrowArray finalized = local_state.appender->Finalize();
+  nanoarrow::UniqueArray arr(&finalized);
+  local_state.serializer->Serialize(*arr.get());
   arrow_serialized_ipc_buffer = local_state.serializer->GetHeader();
   auto body = local_state.serializer->GetBody();
   idx_t ipc_buffer_size = arrow_serialized_ipc_buffer->size_bytes;
@@ -111,7 +116,6 @@ OperatorResultType ToArrowIPCFunction::Function(ExecutionContext& context,
 
   bool caching_disabled =
       PhysicalOperator::SelectOperatorCachingMode(context) == OperatorCachingMode::NONE;
-  local_state.serializer->Init(&data.schema, data.logical_types);
 
   if (!local_state.checked_schema) {
     if (!global_state.sent_schema) {

--- a/test/python/requirements-dev.txt
+++ b/test/python/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 pyarrow
+psutil

--- a/test/python/test_arrow_ipc_memory.py
+++ b/test/python/test_arrow_ipc_memory.py
@@ -1,0 +1,51 @@
+import gc
+
+import psutil
+
+# One call emits several IPC record batches. The leak this guards against scaled
+# with the number of batches that got serialized, so a multi-batch result makes
+# it show up quickly.
+LEAK_QUERY = """
+    SELECT count(*), sum(octet_length(ipc))
+    FROM to_arrow_ipc((SELECT i, i % 7 = 0 AS flag FROM range(1000000) t(i)))
+"""
+
+# Long enough for the allocator to settle before the window opens. How many
+# calls that takes varies by machine, so err on the generous side.
+WARMUP_ITERATIONS = 8
+MEASURED_ITERATIONS = 10
+# to_arrow_ipc used to retain ~10 MiB of native memory per call for this query,
+# so the measured window grew by 96.6 MiB. Once the appender's array, the IPC
+# encoder and the bound schema are released, what is left is allocator drift:
+# a few MiB at most, and it does not accumulate. That leaves this threshold
+# comfortably clear of both outcomes.
+MAX_GROWTH_MIB = 32
+
+
+def rss_mib():
+    return psutil.Process().memory_info().rss / (1024 * 1024)
+
+
+class TestArrowIPCMemory(object):
+    def test_to_arrow_ipc_does_not_retain_memory(self, connection):
+        connection.execute("SET threads=1")
+
+        # The aggregate is computed inside DuckDB, so the blobs never cross into
+        # Python and anything we measure is native memory held by the extension.
+        expected = connection.execute(LEAK_QUERY).fetchone()
+        assert expected[0] > 2, "query is expected to emit several IPC messages"
+
+        for _ in range(WARMUP_ITERATIONS):
+            connection.execute(LEAK_QUERY).fetchone()
+        gc.collect()
+        before = rss_mib()
+
+        for _ in range(MEASURED_ITERATIONS):
+            assert connection.execute(LEAK_QUERY).fetchone() == expected
+        gc.collect()
+        growth = rss_mib() - before
+
+        assert growth < MAX_GROWTH_MIB, (
+            f"RSS grew by {growth:.1f} MiB over {MEASURED_ITERATIONS} to_arrow_ipc calls "
+            f"({growth / MEASURED_ITERATIONS:.1f} MiB per call)"
+        )

--- a/test/python/test_arrow_ipc_writer.py
+++ b/test/python/test_arrow_ipc_writer.py
@@ -38,3 +38,36 @@ class TestArrowIPCBufferWriter(object):
             batches.extend(stream_reader)
         arrow_table = pa.Table.from_batches(batches, schema=schema)
         tables_match(connection.execute("FROM arrow_table").fetchall())
+
+    def test_round_trip_multiple_batches(self, connection):
+        # Big enough to be split over several IPC record batches, so the
+        # serializer runs more than once for a single query. A batch holds
+        # 120 * STANDARD_VECTOR_SIZE rows, so keep this comfortably above that
+        # for any vector size the build might use.
+        source = """
+            SELECT i,
+                   i::VARCHAR AS s,
+                   i % 7 = 0 AS f,
+                   CASE WHEN i % 11 = 0 THEN NULL ELSE i * 2 END AS n
+            FROM range(1200000) t(i)
+        """
+        buffers = connection.execute(f"FROM to_arrow_ipc(({source}))").fetchall()
+        assert len(buffers) > 2, "expected more than one data message"
+        assert [header for _, header in buffers] == [True] + [False] * (len(buffers) - 1)
+
+        schema_message = buffers[0][0]
+        batches = []
+        for payload, _ in buffers[1:]:
+            with pa.BufferReader(pa.py_buffer(schema_message + payload)) as reader:
+                stream_reader = ipc.RecordBatchStreamReader(reader)
+                schema = stream_reader.schema
+                batches.extend(stream_reader)
+
+        arrow_table = pa.Table.from_batches(batches, schema=schema)
+        assert connection.execute(
+            f"""
+            SELECT (SELECT count(*) FROM arrow_table),
+                   (SELECT count(*) FROM (({source}) EXCEPT ALL FROM arrow_table)),
+                   (SELECT count(*) FROM (FROM arrow_table EXCEPT ALL ({source})))
+            """
+        ).fetchone() == (1200000, 0, 0)

--- a/test/sql/to_arrow_ipc.test
+++ b/test/sql/to_arrow_ipc.test
@@ -25,3 +25,37 @@ WITH data_union AS (
     SELECT * FROM data
 )
 FROM to_arrow_ipc((SELECT * FROM data_union ORDER BY col))
+
+# A result bigger than one IPC batch makes the serializer run several times per
+# query, which no other test in this file reaches. A batch holds
+# 120 * STANDARD_VECTOR_SIZE rows, so the row count has to stay comfortably
+# above that for every vector size the build might use -- do not trim it. The
+# resulting number of data messages varies with the vector size, so only assert
+# that there is more than one, behind a single schema message.
+query III
+SELECT count(*) FILTER (WHERE header),
+       count(*) FILTER (WHERE NOT header) >= 2,
+       min(octet_length(ipc)) > 0
+FROM to_arrow_ipc((
+    SELECT i,
+           i::VARCHAR AS s,
+           i % 7 = 0 AS f,
+           CASE WHEN i % 11 = 0 THEN NULL ELSE i END AS n
+    FROM range(1200000) t(i)
+))
+----
+1	true	true
+
+# Two independent evaluations of the same input have to emit the same messages,
+# byte for byte. This is a determinism check on the serializer's reused state,
+# not a guard on the array's ownership: Serialize() copies the body out before
+# SerializeArray() releases the array, so releasing it too early would corrupt
+# or crash rather than surface as a difference here.
+query II
+WITH q AS (SELECT i, i::VARCHAR AS s FROM range(1200000) t(i)),
+     run_a AS MATERIALIZED (SELECT ipc FROM to_arrow_ipc((FROM q))),
+     run_b AS MATERIALIZED (SELECT ipc FROM to_arrow_ipc((FROM q)))
+SELECT (SELECT count(*) FROM run_a) = (SELECT count(*) FROM run_b),
+       (SELECT count(*) FROM (FROM run_a EXCEPT ALL FROM run_b))
+----
+true	0


### PR DESCRIPTION
## Problem

Every call to `to_arrow_ipc()` retains native memory that is never returned. Process RSS grows linearly with the number of calls while `duckdb_memory()` stays at 0 B, and the retained amount scales with the number of rows serialized rather than with the data scanned. A service that used `FROM to_arrow_ipc((<sql>))` as its result transport went from ~300 MiB to a 4 GiB container limit within hours of ordinary traffic.

Verified here against the pinned submodule (DuckDB v1.5.0) and, separately, against DuckDB v1.5.5. The extension builds against v1.5.5 with no source changes, and the leak is byte-for-byte identical there: `ArrowAppender::Finalize()` still hands ownership to the caller, `~ArrowAppender()` is still empty, and `ArrowBuffer::ReserveInternal` still uses raw `malloc` — the only change between the two is an added out-of-memory check.

It was first observed on v1.5.2 and v1.4.4, on macOS arm64 and on Linux x64 under both glibc and jemalloc, so it is neither a 1.5.x regression nor allocator retention.

## Root cause

Three places on the `to_arrow_ipc` path take ownership of something and never release it — four leak roots in total, since the second one orphans two objects.

**1. The finalized `ArrowArray` (dominant).** `ArrowAppender::Finalize()` sets `result.private_data = root_holder.release()` and `result.release = ArrowAppender::ReleaseArray` — ownership moves to the caller, and `~ArrowAppender()` is empty. `SerializeArray()` stored the result in a local `ArrowArray` and never called `release`, so the whole `ArrowAppendData` tree leaked once per emitted data message.

The magnitude comes from the appender's up-front reservation: `chunk_size = DEFAULT_CHUNK_SIZE (120) * STANDARD_VECTOR_SIZE (2048) = 245,760` rows, and `ArrowScalarData::Initialize` does `GetMainBuffer().reserve(capacity * sizeof(TGT))`. That is 2 MiB for a `BIGINT` column and 4 MiB for a `HUGEINT` one, independent of how many rows are actually appended. `ArrowBuffer` uses plain `malloc`/`realloc`/`free`, outside DuckDB's accounting — which is exactly why `duckdb_memory()` reads 0 B throughout.

**2. `ColumnDataCollectionSerializer::Init()` called per input chunk.** `Function()` invoked it as its first statement, i.e. once per incoming `DataChunk`. Inside, `ArrowIpcEncoderInit()` does `memset(encoder, 0, …)` followed by a fresh `ArrowMalloc` + `flatcc_builder_init`, and `ArrowArrayViewInitFromSchema()` reaches `ArrowArrayViewInitFromType()`, which memsets the view before allocating new children. Neither frees what was there, so every chunk leaked an encoder and an array view. This is why a 1M-row projection (489 input chunks) leaked far more than a 977-row aggregate with the same number of IPC messages.

**3. The bind-data `ArrowSchema`.** `ArrowConverter::ToArrowSchema()` produces an owning schema with `release = ReleaseDuckDBArrowSchema`. `ToArrowIpcFunctionData` held it by value with no destructor, leaking one `DuckDBArrowSchemaHolder` per bind.

## Fix

- `SerializeArray()` adopts the finalized array into a `nanoarrow::UniqueArray`, which releases it on scope exit. This is safe because the serializer only reads through an `ArrowArrayView` during `Serialize()`; the encoded bytes are already copied into the header and body buffers by the time it returns.
- The serializer is initialized once per local state instead of once per input chunk. As a side effect this also drops a per-chunk `ArrowTypeExtensionData::GetExtensionTypes()` rebuild from the hot path.
- `Init()` releases previous state (`header`, `body`, `encoder`, `chunk_view`) before re-initializing, so calling it more than once can no longer leak. On a freshly constructed serializer this is a no-op. It also protects `ArrowStreamWriter::NewSerializer()` from the same mistake later.
- `ToArrowIpcFunctionData::schema` becomes a `nanoarrow::UniqueSchema`, matching what `ArrowStreamWriter` already does.

## Measurements

`leaks --atExit` with `MallocStackLogging=1` on macOS arm64, three iterations of

```sql
FROM to_arrow_ipc((SELECT i % 977 AS g, sum(i) AS s FROM range(3000000) t(i) GROUP BY g));
```

Reproducible from a `make reldebug` build with the bundled shell, nothing else needed. `SET threads=1` matters: the number of leaked encoders and array views tracks the number of input chunks, so at the default thread count the aggregate arrives in more chunks and the totals come out higher.

```bash
Q="FROM to_arrow_ipc((SELECT i % 977 AS g, sum(i) AS s FROM range(3000000) t(i) GROUP BY g));"
MallocStackLogging=1 leaks --atExit -- ./build/reldebug/duckdb -c "SET threads=1; $Q $Q $Q"
```

Before — **19,290,912 bytes in 109 blocks**:

| root leak | bytes / 3 iterations |
|---|---|
| `ArrowAppender::Finalize()` | 18.4 MiB |
| `ArrowIpcEncoderInit` | 14.3 KiB |
| `ArrowConverter::ToArrowSchema` | 1.6 KiB |
| `ArrowArrayViewInitFromSchema` | 1.4 KiB |

After — `0 leaks for 0 total leaked bytes`. Same result for a `VARCHAR`/`BOOLEAN` payload and for `COPY … TO … (FORMAT arrows)`.

Rebuilt against DuckDB v1.5.5, the same run reports the same 19,290,912 bytes across the same four roots before the change and `0 leaks for 0 total leaked bytes` after.

Growth per call over 15–40 iterations on one connection, reading every blob to completion. Unlike the table above, this one is not reproducible from the repository: it comes from a small standalone driver on the DuckDB C API that reports RSS, malloc's in-use total across every zone, and `duckdb_memory()` after each iteration. `malloc in-use` is the column that carries the argument here, and the shell cannot report it. The driver is not part of this PR — happy to attach it if it would help review.

| query | ΔRSS before | ΔRSS after | Δmalloc in-use before → after |
|---|---|---|---|
| `SELECT i % 977 AS g, sum(i) FROM range(3000000) GROUP BY g` | +2.01 MiB | +0.08 MiB | +6.07 → +0.00 MiB |
| `SELECT i % 977 AS g, sum(i) FROM range(300000) GROUP BY g` | +2.08 MiB | +0.17 MiB | +6.07 → +0.00 MiB |
| `SELECT i FROM range(1000000)` | +10.53 MiB | +0.16 MiB | +10.53 → +0.00 MiB |
| `SELECT sum(i) FROM range(3000000)` | +0.06 MiB | +0.01 MiB | +4.04 → +0.00 MiB |
| control, same query without `to_arrow_ipc` | +0.16 MiB | — | +0.00 MiB |

On DuckDB v1.5.5 the same two headline queries give +1.95 MiB and +10.12 MiB per call before the change, and +0.08 MiB and +0.01 MiB after.

The single-row case is worth calling out: RSS barely moves, but 4 MiB per call is still leaked. The reserved `HUGEINT` buffer is never touched, so its pages never become resident — the leak is only visible in malloc's in-use total. After the fix, `malloc in-use` is exactly flat in every case, and RSS on the 1M-row query plateaus at 45.2 MiB from the third iteration through the fortieth.

## Tests

`test/python/test_arrow_ipc_memory.py` is the regression test. It measures RSS growth over 10 calls after 8 warm-up calls, aggregating inside DuckDB (`sum(octet_length(ipc))`) so the blobs never cross into Python and anything measured is native memory. Against the unfixed extension it fails with `RSS grew by 96.6 MiB over 10 to_arrow_ipc calls (9.7 MiB per call)`.

The threshold is 32 MiB. What remains on a fixed build is allocator drift rather than retention: it does not accumulate, but how much of it lands inside the window depends on the machine — 0.3 MiB measured here, a few MiB reported on other hardware. The warm-up is deliberately generous for that reason. This adds `psutil` to `requirements-dev.txt` — `resource.ru_maxrss` is a lifetime maximum and would report no growth if an earlier test in the same pytest process had already pushed the peak up.

It is the only guard on the leak, deliberately: nothing about it is observable from SQL — `duckdb_memory()` reads 0 B throughout, and the emitted bytes are identical either way — so no sqllogictest can catch it.

What it guards is root 1, though, not all four. At 32 MiB over 10 calls, anything below roughly 3 MiB per call is invisible, and roots 2 and 4 are well under that on their own: restoring just the per-chunk `Init()` while keeping the rest of the fix leaks 0.48 MiB per call on this query — `leaks` reports 1,520,976 bytes in 6,012 blocks over three iterations, 1,467 encoders and 1,467 array views — and the test passes with 7.1 MiB of growth. Tightening the threshold to catch that would trade a real guard on the 10 MiB/call regression for a flaky one, so the coverage gap is accepted rather than closed.

The remaining new tests are correctness coverage and pass against the unfixed extension too. The existing `to_arrow_ipc` tests all run on four-row inputs, so the multi-batch path, where the serializer runs several times per query, was not exercised anywhere. Added:

- `test/sql/to_arrow_ipc.test`: a 1.2M-row mixed-type result yields exactly one schema message and more than one data message (the exact count depends on `STANDARD_VECTOR_SIZE`, so it is not pinned); two independent evaluations of the same input emit the same messages byte for byte.
- `test/python/test_arrow_ipc_writer.py`: a 1.2M-row round trip reassembled through `pyarrow` and compared with `EXCEPT ALL` in both directions.

A batch holds `120 * STANDARD_VECTOR_SIZE` rows, so both row counts are chosen to stay above that for any vector size a build is likely to use rather than to sit just past the default; the comments say so, since trimming them would silently turn these into single-batch tests.
